### PR TITLE
v2.0.0 - update cards to be timezone aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # IDE
 .idea
 .vscode
+
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ pip install fsrs
 
 Create a card and review it at a given time:
 ```python
+from datetime import datetime, UTC
 from fsrs import *
 f = FSRS()
 card = Card()
-now = datetime(2022, 11, 29, 12, 30, 0, 0)
+# (py-fsrs cards use UTC)
+now = datetime(2022, 11, 29, 12, 30, 0, 0, tzinfo=UTC) 
 scheduling_cards = f.repeat(card, now)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "1.2.0"
+version = "2.0.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [{ name = "Jarrett Ye", email = "jarrett.ye@outlook.com" }]

--- a/src/fsrs/__init__.py
+++ b/src/fsrs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "2.0.0"
 
 from .fsrs import FSRS, Card
 

--- a/src/fsrs/fsrs.py
+++ b/src/fsrs/fsrs.py
@@ -1,5 +1,6 @@
 from .models import *
 import math
+from datetime import timezone
 
 
 class FSRS:
@@ -13,6 +14,10 @@ class FSRS:
         self.FACTOR = 0.9 ** (1 / self.DECAY) - 1
 
     def repeat(self, card: Card, now: datetime) -> dict[int, SchedulingInfo]:
+
+        if (now.tzinfo is None) or (now.tzinfo != timezone.utc):
+            raise ValueError("datetime must be timezone-aware and set to UTC")
+
         card = copy.deepcopy(card)
         if card.state == State.New:
             card.elapsed_days = 0

--- a/src/fsrs/models.py
+++ b/src/fsrs/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import copy
 from typing import Tuple, Optional
 from enum import IntEnum
@@ -22,7 +22,7 @@ class ReviewLog:
     rating: int
     scheduled_days: int
     elapsed_days: int
-    Review: datetime
+    review: datetime
     state: int
 
     def __init__(
@@ -52,7 +52,7 @@ class Card:
     last_review: datetime
 
     def __init__(self) -> None:
-        self.due = datetime.utcnow()
+        self.due = datetime.now(UTC)
         self.stability = 0
         self.difficulty = 0
         self.elapsed_days = 0


### PR DESCRIPTION
PR to address issue #28 

- New card objects when created are now timezone-aware in addition to being UTC
- When cards are repeated, the time value they receive must be timezone-aware and UTC
- Updated the README with new example
- Added new tests and modified the old one
- Bumped major version from 1.2.0 -> 2.0.0 since these are breaking changes

For developers using previous versions of py-fsrs, they can update an old card object by using the following code:
```python
# where card_object is a v1 py-fsrs card...
import datetime
card_object.due = card_object.due.replace(tzinfo=datetime.timezone.utc)
if hasattr(card_object, 'last_review'):
    card_object.last_review = card_object.last_review.replace(tzinfo=datetime.timezone.utc)
```

Let me know if there are any questions or issues 👍