### PR TITLE
v2.1.0 - make Card objects JSON serializable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "2.0.0"
+version = "2.1.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [{ name = "Jarrett Ye", email = "jarrett.ye@outlook.com" }]

--- a/src/fsrs/__init__.py
+++ b/src/fsrs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 from .fsrs import FSRS, Card
 

--- a/src/fsrs/models.py
+++ b/src/fsrs/models.py
@@ -51,15 +51,81 @@ class Card:
     state: State
     last_review: datetime
 
-    def __init__(self) -> None:
-        self.due = datetime.now(UTC)
-        self.stability = 0
-        self.difficulty = 0
-        self.elapsed_days = 0
-        self.scheduled_days = 0
-        self.reps = 0
-        self.lapses = 0
-        self.state = State.New
+    def __init__(
+        self,
+        due=None,
+        stability=0,
+        difficulty=0,
+        elapsed_days=0,
+        scheduled_days=0,
+        reps=0,
+        lapses=0,
+        state=State.New,
+        last_review=None,
+    ) -> None:
+
+        if due is None:
+            self.due = datetime.now(UTC)
+        else:
+            self.due = due
+
+        self.stability = stability
+        self.difficulty = difficulty
+        self.elapsed_days = elapsed_days
+        self.scheduled_days = scheduled_days
+        self.reps = reps
+        self.lapses = lapses
+        self.state = state
+
+        if last_review is not None:
+            self.last_review = last_review
+
+    def to_dict(self):
+
+        return_dict = {
+            "due": self.due.isoformat(),
+            "stability": self.stability,
+            "difficulty": self.difficulty,
+            "elapsed_days": self.elapsed_days,
+            "scheduled_days": self.scheduled_days,
+            "reps": self.reps,
+            "lapses": self.lapses,
+            "state": self.state,
+        }
+
+        if hasattr(self, "last_review"):
+            return_dict["last_review"] = self.last_review.isoformat()
+
+        return return_dict
+
+    @staticmethod
+    def from_dict(source_dict):
+
+        due = datetime.fromisoformat(source_dict["due"])
+        stability = source_dict["stability"]
+        difficulty = source_dict["difficulty"]
+        elapsed_days = source_dict["elapsed_days"]
+        scheduled_days = source_dict["scheduled_days"]
+        reps = source_dict["reps"]
+        lapses = source_dict["lapses"]
+        state = source_dict["state"]
+
+        if "last_review" in source_dict:
+            last_review = datetime.fromisoformat(source_dict["last_review"])
+        else:
+            last_review = None
+
+        return Card(
+            due,
+            stability,
+            difficulty,
+            elapsed_days,
+            scheduled_days,
+            reps,
+            lapses,
+            state,
+            last_review,
+        )
 
     def get_retrievability(self, now: datetime) -> Optional[float]:
         DECAY = -0.5


### PR DESCRIPTION
PR to address issue #32 

- Added a `.to_dict()` method to the Card class so that Card objects can now be represented as json-serializable dictionaries for storage in databases
  ```python
  card_obj = Card()
  card_dict = card_obj.to_dict()
  card_json = json.dumps(card_dict)
  ```
- Added a static `.from_dict()` method to the Card class so that data from previously serialized card objects can be used to reconstruct new Card objects
  ```python
  new_card_obj = Card.from_dict(card_dict)
  ```
- Added `test_serialize` in tests/test_fsrs.py to test this feature
- Bumped version from 2.0.0 -> 2.1.0 as this feature is backward compatible

Let me know if there are any questions or issues 👍