### PR TITLE
Use lower case for attribute in SchedulingInfo

### DIFF
--- a/src/fsrs/models.py
+++ b/src/fsrs/models.py
@@ -140,7 +140,7 @@ class Card:
 
 class SchedulingInfo:
     card: Card
-    Review_log: ReviewLog
+    review_log: ReviewLog
 
     def __init__(self, card: Card, review_log: ReviewLog) -> None:
         self.card = card


### PR DESCRIPTION
fix a typo: its a review_log, not Review_log