### PR TITLE
add default argument to repeat function

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Import and initialize the FSRS scheduler
 
 ```python
 from fsrs import *
-from datetime import datetime, UTC, timezone
 
 f = FSRS()
 ```
@@ -49,12 +48,9 @@ Create a new Card object
 card_object = Card()
 ```
 
-Review the card at a specified time
+Review the card
 ```python
-# all py-fsrs cards must be UTC and timezone-aware
-review_time = datetime.now(UTC)
-
-scheduling_cards = f.repeat(card_object, review_time)
+scheduling_cards = f.repeat(card_object)
 ```
 
 Choose a rating and update the card object
@@ -74,10 +70,12 @@ card_object = scheduling_cards[card_rating].card
 
 See when the card is due next
 ```python
+from datetime import datetime, timezone
+
 due = card_object.due
 
 # how much time between when the card is due and now
-time_delta = due - datetime.now(UTC)
+time_delta = due - datetime.now(timezone.utc)
 
 print(f"Card due: at {repr(due)}")
 print(f"Card due in {time_delta.seconds} seconds")

--- a/README.md
+++ b/README.md
@@ -6,16 +6,10 @@
   <em>🧠🔄 Build your own Spaced Repetition System in Python 🧠🔄   </em>
 </div>
 <br />
-<div align="center">
-    <a href="https://pypi.org/project/fsrs/">
-        <img src="https://img.shields.io/pypi/v/fsrs">
-    </a>
-    <a href="https://github.com/open-spaced-repetition/py-fsrs/blob/main/LICENSE">
-        <img src="https://img.shields.io/badge/License-MIT-brightgreen.svg">
-    </a>
-    <a href="https://github.com/psf/black">
-        <img src="https://img.shields.io/badge/code%20style-black-000000.svg">
-    </a>
+<div align="center" style="text-decoration: none;">
+    <a href="https://pypi.org/project/fsrs/"><img src="https://img.shields.io/pypi/v/fsrs"></a>
+    <a href="https://github.com/open-spaced-repetition/py-fsrs/blob/main/LICENSE" style="text-decoration: none;"><img src="https://img.shields.io/badge/License-MIT-brightgreen.svg"></a>
+    <a href="https://github.com/psf/black" style="text-decoration: none;"><img src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </div>
 <br />
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "2.1.1"
+version = "2.2.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [{ name = "Jarrett Ye", email = "jarrett.ye@outlook.com" }]

--- a/src/fsrs/__init__.py
+++ b/src/fsrs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 from .fsrs import FSRS, Card
 

--- a/src/fsrs/fsrs.py
+++ b/src/fsrs/fsrs.py
@@ -13,7 +13,10 @@ class FSRS:
         self.DECAY = -0.5
         self.FACTOR = 0.9 ** (1 / self.DECAY) - 1
 
-    def repeat(self, card: Card, now: datetime) -> dict[int, SchedulingInfo]:
+    def repeat(self, card: Card, now: datetime = None) -> dict[int, SchedulingInfo]:
+
+        if now is None:
+            now = datetime.now(timezone.utc)
 
         if (now.tzinfo is None) or (now.tzinfo != timezone.utc):
             raise ValueError("datetime must be timezone-aware and set to UTC")

--- a/tests/test_fsrs.py
+++ b/tests/test_fsrs.py
@@ -72,6 +72,25 @@ class TestPyFSRS:
         print(ivl_history)
         assert ivl_history == [0, 5, 16, 43, 106, 236, 0, 0, 12, 25, 47, 85, 147]
 
+    def test_repeat_default_arg(self):
+
+        f = FSRS()
+
+        card_object = Card()
+
+        # repeat time is not specified
+        scheduling_cards = f.repeat(card_object)
+
+        card_rating = Rating.Good
+
+        card_object = scheduling_cards[card_rating].card
+
+        due = card_object.due
+
+        time_delta = due - datetime.now(timezone.utc)
+
+        assert time_delta.seconds > 500  # due in approx. 8-10 minutes
+
     def test_datetime(self):
 
         f = FSRS()


### PR DESCRIPTION
I modified the `repeat` function to take a default argument for the datetime variable thus making it entirely optional for developers to create and pass a datetime object if they want to repeat a card.

Now instead of having to do
```python
scheduling_cards = f.repeat(card_object, datetime.now(timezone.utc))
```
developers can instead write
```python
scheduling_cards = f.repeat(card_object)
```
if they want to repeat the card 'now'.

I also did the following:
1. Bumped minor version: 2.1.1 -> 2.2.0
2. Added a test for this new functionality
3. Modified the README's `repeat` function example to use the default parameter.

Let me know if this sounds good, or if there are any issues or questions 👍