### PR TITLE
make ReviewLog objects JSON-serializable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "2.2.1"
+version = "2.3.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [{ name = "Jarrett Ye", email = "jarrett.ye@outlook.com" }]

--- a/src/fsrs/__init__.py
+++ b/src/fsrs/__init__.py
@@ -1,5 +1,3 @@
-__version__ = "2.2.1"
+__version__ = "2.3.0"
 
-from .fsrs import FSRS, Card
-
-from .fsrs import State, Rating
+from .fsrs import FSRS, Card, ReviewLog, State, Rating

--- a/src/fsrs/models.py
+++ b/src/fsrs/models.py
@@ -39,6 +39,35 @@ class ReviewLog:
         self.review = review
         self.state = state
 
+    def to_dict(self):
+
+        return_dict = {
+            "rating": self.rating,
+            "scheduled_days": self.scheduled_days,
+            "elapsed_days": self.elapsed_days,
+            "review": self.review.isoformat(),
+            "state": self.state,
+        }
+
+        return return_dict
+
+    @staticmethod
+    def from_dict(source_dict):
+
+        rating = source_dict["rating"]
+        scheduled_days = source_dict["scheduled_days"]
+        elapsed_days = source_dict["elapsed_days"]
+        review = datetime.fromisoformat(source_dict["review"])
+        state = source_dict["state"]
+
+        return ReviewLog(
+            rating,
+            scheduled_days,
+            elapsed_days,
+            review,
+            state,
+        )
+
 
 class Card:
     due: datetime


### PR DESCRIPTION
I made ReviewLog objects JSON-serializable so that these logs can be easily stored in databases. The changes are very similar to the changes made in #33 for Card objects.

Changes:
- Added `.to_dict()` method to ReviewLog for serialization
- Added static `.from_dict()` method for deserialization
- Added a new test: `test_ReviewLog_serialize` to test the serialization
- Bumped from version 2.2.1 -> 2.3.0