### PR TITLE
feat/add review_card function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,10 @@ f = FSRS()
 Create a new Card object
 ```python
 # all new cards are 'due' immediately upon creation
-card_object = Card()
+card = Card()
 ```
 
-Review the card
-```python
-scheduling_cards = f.repeat(card_object)
-```
-
-Choose a rating and update the card object
+Choose a rating and review the card
 ```python
 # you can choose one of the four possible ratings
 """
@@ -61,16 +56,16 @@ Rating.Good # recall; correct response after a hesitation
 Rating.Easy # recall; perfect response
 """
 
-card_rating = Rating.Good
+rating = Rating.Good
 
-card_object = scheduling_cards[card_rating].card
+card, review_log = f.review_card(card, rating)
 ```
 
 See when the card is due next
 ```python
 from datetime import datetime, timezone
 
-due = card_object.due
+due = card.due
 
 # how much time between when the card is due and now
 time_delta = due - datetime.now(timezone.utc)
@@ -79,7 +74,7 @@ print(f"Card due: at {repr(due)}")
 print(f"Card due in {time_delta.seconds} seconds")
 
 """
-> Card due: at datetime.datetime(2024, 7, 6, 20, 6, 39, 147417, tzinfo=datetime.timezone.utc)
+> Card due: at datetime.datetime(2024, 7, 12, 18, 16, 4, 429428, tzinfo=datetime.timezone.utc)
 > Card due in: 599 seconds
 """
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "2.3.0"
+version = "2.4.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [{ name = "Jarrett Ye", email = "jarrett.ye@outlook.com" }]

--- a/src/fsrs/__init__.py
+++ b/src/fsrs/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 from .fsrs import FSRS, Card, ReviewLog, State, Rating

--- a/src/fsrs/fsrs.py
+++ b/src/fsrs/fsrs.py
@@ -13,6 +13,17 @@ class FSRS:
         self.DECAY = -0.5
         self.FACTOR = 0.9 ** (1 / self.DECAY) - 1
 
+    def review_card(
+        self, card: Card, rating: Rating, now: datetime = None
+    ) -> tuple[Card, ReviewLog]:
+
+        scheduling_cards = self.repeat(card, now)
+
+        card = scheduling_cards[rating].card
+        review_log = scheduling_cards[rating].review_log
+
+        return card, review_log
+
     def repeat(self, card: Card, now: datetime = None) -> dict[int, SchedulingInfo]:
 
         if now is None:

--- a/tests/test_fsrs.py
+++ b/tests/test_fsrs.py
@@ -202,3 +202,59 @@ class TestPyFSRS:
         # original review log and next review log are different
         assert vars(review_log) != vars(next_review_log)
         assert review_log.to_dict() != next_review_log.to_dict()
+
+    def test_review_card(self):
+
+        f = FSRS()
+        f.p.w = (
+            1.14,
+            1.01,
+            5.44,
+            14.67,
+            5.3024,
+            1.5662,
+            1.2503,
+            0.0028,
+            1.5489,
+            0.1763,
+            0.9953,
+            2.7473,
+            0.0179,
+            0.3105,
+            0.3976,
+            0.0,
+            2.0902,
+        )
+        card = Card()
+        now = datetime(2022, 11, 29, 12, 30, 0, 0, timezone.utc)
+        # scheduling_cards = f.repeat(card, now)
+        # print_scheduling_cards(scheduling_cards)
+
+        ratings = (
+            Rating.Good,
+            Rating.Good,
+            Rating.Good,
+            Rating.Good,
+            Rating.Good,
+            Rating.Good,
+            Rating.Again,
+            Rating.Again,
+            Rating.Good,
+            Rating.Good,
+            Rating.Good,
+            Rating.Good,
+            Rating.Good,
+        )
+        ivl_history = []
+
+        for rating in ratings:
+            # card = scheduling_cards[rating].card
+            card, _ = f.review_card(card, rating, now)
+            ivl = card.scheduled_days
+            ivl_history.append(ivl)
+            now = card.due
+            # scheduling_cards = f.repeat(card, now)
+            # print_scheduling_cards(scheduling_cards)
+
+        print(ivl_history)
+        assert ivl_history == [0, 5, 16, 43, 106, 236, 0, 0, 12, 25, 47, 85, 147]


### PR DESCRIPTION
I added a new function `review_card` to the FSRS class to make reviewing cards more straightforward.

Now instead of having to review cards like:
```python
rating = Rating.Good
scheduling_cards = f.repeat(card)

card = scheduling_cards[rating].card
review_log = scheduling_cards[rating].review_log
```

Developers can write:
```python
rating = Rating.Good

card, review_log = f.review_card(card, rating)
```

Let me know if this level of abstraction is welcome 👍

Other changes:
- Bumped version from 2.3.0 -> 2.4.0
- Added test to for the `review_card` function
- Updated the Quickstart section in the README to use `review_card`