### PR TITLE
mypy contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,18 +36,23 @@ Now you're ready to make changes to `src/fsrs` and see your changes reflected im
 
 This project follows [semantic versioning](https://semver.org/), so please make sure to increment the version number in [pyproject.toml](pyproject.toml) when contributing new code.
 
-### Lint, format and test
+### Lint, type-check, format and test
 
-Py-FSRS uses [Ruff](https://github.com/astral-sh/ruff) for linting and formatting and uses [pytest](https://docs.pytest.org) to run its tests. In order for your contribution to be accepted, your code must pass linting/formatting checks and be able to pass the tests.
+Py-FSRS uses [Ruff](https://github.com/astral-sh/ruff) for linting and formatting, [mypy](https://mypy-lang.org/) for static type-checking and [pytest](https://docs.pytest.org) to run its tests. In order for your contribution to be accepted, your code must pass the linting, type-checking and formatting checks as well as the tests.
 
 You can install these packages with
 ```
-pip install ruff pytest
+pip install ruff mypy pytest
 ```
 
 Lint your code with:
 ```
 ruff check --fix
+```
+
+Run the type-checker:
+```
+mypy .
 ```
 
 Format your code with:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,8 @@ Homepage = "https://github.com/open-spaced-repetition/py-fsrs"
 [tool.ruff.lint]
 ignore = ["F401", "F403", "F405", "E721"]
 
+[tool.pytest.ini_options]
+pythonpath = "src"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-pythonpath = src


### PR DESCRIPTION
I moved the `pytest.ini` and `mypy.ini` files into `pyproject.toml` to reduce clutter in the repo.

I also added instructions in CONTRIBUTING for how contributors can run the mypy type-checker so that their contributions can pass the mypy workflow added in #48. 

I will say that I want to be cautious about adding too much in the way of contributing though. We currently have checks for linting, type-checking and tests and I'm not sure if it's a good idea to add too much more stuff since it might discourage new contributors.

Anyways, lmk if you have any questions or issues 👍