### PR TITLE
remove wildcard imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install fsrs
 Import and initialize the FSRS scheduler
 
 ```python
-from fsrs import *
+from fsrs import FSRS, Card, Rating
 
 f = FSRS()
 ```

--- a/src/fsrs/fsrs.py
+++ b/src/fsrs/fsrs.py
@@ -1,7 +1,16 @@
-from .models import *
+from .models import (
+    Card,
+    ReviewLog,
+    Rating,
+    State,
+    SchedulingCards,
+    SchedulingInfo,
+    Parameters,
+)
 import math
-from datetime import timezone
-from typing import Optional
+from datetime import datetime, timezone, timedelta
+from typing import Optional, Tuple
+import copy
 
 
 class FSRS:


### PR DESCRIPTION
I went and removed the wildcard imports from both the `fsrs.py` module and the `README.md` file as it's generally considered better practice not to use wildcard imports.

Let me know if there are any questions/issues