### PR TITLE
compute retrievability for all states

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "3.0.0"
+version = "3.1.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [{ name = "Jarrett Ye", email = "jarrett.ye@outlook.com" }]

--- a/src/fsrs/models.py
+++ b/src/fsrs/models.py
@@ -262,7 +262,7 @@ class Card:
             last_review,
         )
 
-    def get_retrievability(self, now: datetime) -> Optional[float]:
+    def get_retrievability(self, now: Optional[datetime] = None) -> float:
         """
         Calculates the Card object's current retrievability for a given date and time.
 
@@ -270,16 +270,19 @@ class Card:
             now (datetime): The current date and time
 
         Returns:
-            Optional[float]: The retrievability of the Card object if it's in the Review state, otherwise, will return None.
+            float: The retrievability of the Card object.
         """
         DECAY = -0.5
         FACTOR = 0.9 ** (1 / DECAY) - 1
 
-        if self.state == State.Review:
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        if self.state in (State.Learning, State.Review, State.Relearning):
             elapsed_days = max(0, (now - self.last_review).days)
             return (1 + FACTOR * elapsed_days / self.stability) ** DECAY
         else:
-            return None
+            return 0
 
 
 @dataclass

--- a/tests/test_fsrs.py
+++ b/tests/test_fsrs.py
@@ -1,4 +1,4 @@
-from fsrs import *
+from fsrs import FSRS, Card, ReviewLog, State, Rating
 from datetime import datetime, timedelta, timezone
 import json
 import pytest
@@ -310,3 +310,31 @@ class TestPyFSRS:
         assert f2.p.w == w2
         assert f2.p.request_retention == request_retention2
         assert f2.p.maximum_interval == maximum_interval2
+
+    def test_retrievability(self):
+        f = FSRS()
+
+        card = Card()
+
+        # retrievabiliy of New card
+        assert card.state == State.New
+        retrievability = card.get_retrievability()
+        assert retrievability == 0
+
+        # retrievabiliy of Learning card
+        card, _ = f.review_card(card, Rating.Good)
+        assert card.state == State.Learning
+        retrievability = card.get_retrievability()
+        assert 0 <= retrievability <= 1
+
+        # retrievabiliy of Review card
+        card, _ = f.review_card(card, Rating.Good)
+        assert card.state == State.Review
+        retrievability = card.get_retrievability()
+        assert 0 <= retrievability <= 1
+
+        # retrievabiliy of Relearning card
+        card, _ = f.review_card(card, Rating.Again)
+        assert card.state == State.Relearning
+        retrievability = card.get_retrievability()
+        assert 0 <= retrievability <= 1


### PR DESCRIPTION
Currently, you can only get a card’s retrievability when it’s in the Review state. I thought it would be good enhancement if you could also compute the retrievability for cards in the other states as well.

Changes:
- Compute retrievability for Learning and Relearning cards the same way it's computed for Review cards
- New cards have 0 retrievability
  - Rationale: given that new cards have S=0, then for t>0, R(t,S) -> 0 as S -> 0(+)
- Made the datetime argument optional for the `get_retrievability` function.
  - If the function is invoked without a given datetime, the datetime defaults to `datetime.now(timezone.utc)` similar to the Card class's `__init__` method or the FSRS class's `review_card` method.
- Bump minor version: 3.0.0 -> 3.1.0
- Add test: `test_retrievability` to demonstrate this change works

Let me know if this makes sense or if you have questions 👍