### PR TITLE
Switch to official ruff gh action

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,8 +1,8 @@
 name: Ruff
-on: [ push, pull_request ]
+on: [push, pull_request]
 jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v1


### PR DESCRIPTION
The previous unofficial ruff gh action that we were using is no longer maintained: https://github.com/ChartBoost/ruff-action.

I switched our ruff gh action to the official version: https://github.com/astral-sh/ruff-action

Let me know if there are any questions.