### PR TITLE
Fixes type bug where difficulty became an int if it exceeded the thresholds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "4.1.1"
+version = "4.1.2"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [{ name = "Jarrett Ye", email = "jarrett.ye@outlook.com" }]

--- a/src/fsrs/fsrs.py
+++ b/src/fsrs/fsrs.py
@@ -663,7 +663,7 @@ class Scheduler:
         )
 
         # bound initial_difficulty between 1 and 10
-        initial_difficulty = min(max(initial_difficulty, 1), 10)
+        initial_difficulty = min(max(initial_difficulty, 1.0), 10.0)
 
         return initial_difficulty
 
@@ -704,7 +704,7 @@ class Scheduler:
         next_difficulty = _mean_reversion(arg_1=arg_1, arg_2=arg_2)
 
         # bound next_difficulty between 1 and 10
-        next_difficulty = min(max(next_difficulty, 1), 10)
+        next_difficulty = min(max(next_difficulty, 1.0), 10.0)
 
         return next_difficulty
 

--- a/tests/test_fsrs.py
+++ b/tests/test_fsrs.py
@@ -55,6 +55,21 @@ class TestPyFSRS:
             142,
         ]
 
+    def test_repeated_correct_reviews(self):
+        scheduler = Scheduler(enable_fuzzing=False)
+
+        card = Card()
+        review_datetimes = [
+            datetime(2022, 11, 29, 12, 30, 0, i, timezone.utc) for i in range(10)
+        ]
+
+        for review_datetime in review_datetimes:
+            card, _ = scheduler.review_card(
+                card=card, rating=Rating.Easy, review_datetime=review_datetime
+            )
+
+        assert card.difficulty == 1.0
+
     def test_memo_state(self):
         scheduler = Scheduler()
 


### PR DESCRIPTION
The lines thresholding the difficulty between 1 and 10 were causing difficulty to become an integer, which then caused it to fail a type check later.

This change:
1. fixes the thresholding of difficulty to be between 1.0 and 10.0
2. adds a test of multiple successful reviews in quick succession to hit this threshold