### PR TITLE
Add optional dev dependencies to pyproject.toml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ Once you've confirmed your version, please report your issue in the [issues tab]
 
 ### Develop
 
-Install the `fsrs` python package locally in editable mode from the src with
+Install `fsrs` locally in editable mode along with the dev dependencies
 ```
-pip install -e .
+pip install -e ".[dev]"
 ```
 
 Now you're ready to make changes to `src/fsrs` and see your changes reflected immediately!
@@ -39,11 +39,6 @@ This project follows [semantic versioning](https://semver.org/), so please make 
 ### Lint, type-check, format and test
 
 Py-FSRS uses [Ruff](https://github.com/astral-sh/ruff) for linting and formatting, [mypy](https://mypy-lang.org/) for static type-checking and [pytest](https://docs.pytest.org) to run its tests. In order for your contribution to be accepted, your code must pass the linting, type-checking and formatting checks as well as the tests.
-
-You can install these packages with
-```
-pip install ruff mypy pytest
-```
 
 Lint your code with:
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ requires-python = ">=3.10"
 [project.urls]
 Homepage = "https://github.com/open-spaced-repetition/py-fsrs"
 
+[project.optional-dependencies]
+dev = ["pytest", "mypy", "ruff"]
+
 [tool.pytest.ini_options]
 pythonpath = "src"
 


### PR DESCRIPTION
Py-FSRS uses Ruff for linting and formatting, mypy for type checking and pytest for unit tests. Currently, when developing locally, each of these dependencies must be installed individually.

To make things a bit more clean, I added optional `dev` dependencies to the pyproject.toml so that installing these dependencies (along with fsrs itself) is more straightforward with just

```
pip install -e ".[dev]"
```

I also updated CONTRIBUTING.md to include instructions on how to install the dev dependencies.

Let me know if you have any questions 👍