### PR TITLE
Improve mypy gh action

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,10 +1,6 @@
 name: mypy
 
-on:
-  pull_request:
-  push:
-    paths:
-      - '*.py'
+on: [push, pull_request]
 
 jobs:
   mypy:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install mypy

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: mypy
 
 on:
   pull_request:
@@ -10,18 +10,14 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          architecture: x64
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Install mypy
-        run: pip install mypy
+        run: |
+            python -m pip install --upgrade pip
+            pip install mypy
       - name: Run mypy
         uses: sasanquaneuf/mypy-github-action@releases/v1
         with:
           checkName: 'mypy'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,6 +9,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
       - name: Install mypy
         run: |
             python -m pip install --upgrade pip


### PR DESCRIPTION
I made some small changes to the mypy gh action to fix some things that have been bugging me a bit

1. The name is now "mypy" instead of "Lint". This makes sense since we already use the Ruff action for linting and mypy is technically used for type checking rather than linting
2. The action is now triggered consistently on all pushes and pull requests like the lint and test actions.
3. The action is no longer tied to the x64 architecture. This means that people using computers with ARM chips (like myself) can now run this action more easily locally. (Before, when I'd run [act](https://github.com/nektos/act), I'd have to run `act --container-architecture linux/amd64`. Now I can just simply run `act`).
4. I also got rid of that secret github token thing since it's not necessary.
5. Etc

Let me know if you have any questions