### PR TITLE
Test multiple versions of python in pytest gh action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,18 @@ jobs:
     test:
 
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            python-version: ["3.10", "3.11", "3.12", "3.13"]
 
         steps:
         - uses: actions/checkout@v4
-        - name: Set up Python
-          uses: actions/setup-python@v3
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v5
           with:
-            python-version: '3.x'
+            python-version: ${{ matrix.python-version }}
+        - name: Display Python version
+          run: python -c "import sys; print(sys.version)"
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 <br />
 <div align="center" style="text-decoration: none;">
     <a href="https://pypi.org/project/fsrs/"><img src="https://img.shields.io/pypi/v/fsrs"></a>
+    <a href="https://pypi.org/project/fsrs/"><img src="https://img.shields.io/badge/python-3.10%2B-blue
+    "></a>
     <a href="https://github.com/open-spaced-repetition/py-fsrs/blob/main/LICENSE" style="text-decoration: none;"><img src="https://img.shields.io/badge/License-MIT-brightgreen.svg"></a>
     <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
 </div>

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 <br />
 <div align="center" style="text-decoration: none;">
     <a href="https://pypi.org/project/fsrs/"><img src="https://img.shields.io/pypi/v/fsrs"></a>
-    <a href="https://pypi.org/project/fsrs/"><img src="https://img.shields.io/badge/python-3.10%2B-blue
-    "></a>
+    <a href="https://pypi.org/project/fsrs/"><img src="https://img.shields.io/badge/python-3.10%2B-blue"></a>
     <a href="https://github.com/open-spaced-repetition/py-fsrs/blob/main/LICENSE" style="text-decoration: none;"><img src="https://img.shields.io/badge/License-MIT-brightgreen.svg"></a>
     <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
 </div>


### PR DESCRIPTION
- I updated our pytest gh action to test multiple versions of python, namely python versions `3.10`, `3.11`, `3.12` and `3.13`.

- I also added a shield to the README to show that python 3.10+ is supported

Let me know if there are any questions!