### PR TITLE
Add __repr__ methods to Card, ReviewLog and Scheduler classes

### DIFF
--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -136,6 +136,18 @@ class Card:
 
         self.last_review = last_review
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"card_id={self.card_id}, "
+            f"state={self.state}, "
+            f"step={self.step}, "
+            f"stability={self.stability}, "
+            f"difficulty={self.difficulty}, "
+            f"due={self.due}, "
+            f"last_review={self.last_review})"
+        )
+
     def to_dict(self) -> dict[str, int | float | str | None]:
         """
         Returns a JSON-serializable dictionary representation of the Card object.
@@ -248,6 +260,15 @@ class ReviewLog:
         self.review_datetime = review_datetime
         self.review_duration = review_duration
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"card_id={self.card_id}, "
+            f"rating={self.rating}, "
+            f"review_datetime={self.review_datetime}, "
+            f"review_duration={self.review_duration})"
+        )
+
     def to_dict(
         self,
     ) -> dict[str, dict | int | str | None]:
@@ -338,6 +359,17 @@ class Scheduler:
         self.relearning_steps = tuple(relearning_steps)
         self.maximum_interval = maximum_interval
         self.enable_fuzzing = enable_fuzzing
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"parameters={self.parameters}, "
+            f"desired_retention={self.desired_retention}, "
+            f"learning_steps={self.learning_steps}, "
+            f"relearning_steps={self.relearning_steps}, "
+            f"maximum_interval={self.maximum_interval}, "
+            f"enable_fuzzing={self.enable_fuzzing})"
+        )
 
     def review_card(
         self,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -680,3 +680,16 @@ class TestPyFSRS:
             card=card, rating=Rating.Good, review_datetime=card.due
         )
         assert (card.due - card.last_review).days <= scheduler.maximum_interval
+
+    def test_class_repr(self):
+        card = Card()
+
+        assert str(card) == repr(card)
+
+        scheduler = Scheduler()
+
+        assert str(scheduler) == repr(scheduler)
+
+        card, review_log = scheduler.review_card(card=card, rating=Rating.Good)
+
+        assert str(review_log) == repr(review_log)


### PR DESCRIPTION
I frequently use the `fsrs` package within jupyter notebooks and would like to be able to more easily see the state of the various fsrs objects I'm working with.

Previously, viewing the state was not straightforward
```python
from fsrs import Card

card = Card()
print(card)
# > <fsrs.fsrs.Card object at 0x1006c6ed0>
```

The indirect workaround was just to use the object's `to_dict()` method
```python
print(card.to_dict())
# > {'card_id': 1737841408759, 'state': 1, 'step': 0, 'stability': None, 'difficulty': None, 'due': '2025-01-25T21:43:28.760953+00:00', 'last_review': None}
```

but this could be made more straight forward by implementing a `__repr__` method to each of the major fsrs classes (currently excluding the `Optimizer` class).

Now with the `__repr__` method, printing the state of the objects is easy.

```python
print(card)
# > Card(card_id=1737841768402, state=1, step=0, stability=None, difficulty=None, due=2025-01-25 21:49:28.404135+00:00, last_review=None)
```

I'll note that the `__repr__` method is basically a more general `__str__` method and that `__repr__` will act as a `__str__` method if one is not implemented, which is why I didn't implement one.

But yeah, tl;dr, I implemented a `__repr__` method for the `Card`, `ReviewLog` and `Scheduler` classes and added a very basic unit test.

Let me know if you have any questions 👍