### PR TITLE
Prevent card id collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,27 +172,6 @@ new_card = Card.from_dict(card_dict)
 new_review_log = ReviewLog.from_dict(review_log_dict)
 ```
 
-### Batch card creation
-
-If you batch create `Card` objects, ensure that you leave at least 1 millisecond between creating each individual card
-
-```python
-from fsrs import Card
-import time
-
-cards = []
-for i in range(100):
-
-    card = Card()
-
-    cards.append(card)
-    
-    # wait 1 millisecond
-    time.sleep(0.001)
-```
-
-Each `Card` object has a `card_id` attribute which is the epoch milliseconds of when the card was created. In order to keep each of the card id's unique, two cards must not be created within 1 millisecond of eachother.
-
 ## Optimizer (optional)
 
 If you have a collection of `ReviewLog` objects, you can optionally reuse them to compute an optimal set of parameters for the `Scheduler` to make it more accurate at scheduling reviews.

--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone, timedelta
 from copy import copy
 from enum import IntEnum
 from random import random
+import time
 
 DEFAULT_PARAMETERS = (
     0.40255,
@@ -119,6 +120,8 @@ class Card:
         if card_id is None:
             # epoch milliseconds of when the card was created
             card_id = int(datetime.now(timezone.utc).timestamp() * 1000)
+            # wait 1ms to prevent potential card_id collision on next Card creation
+            time.sleep(0.001)
         self.card_id = card_id
 
         self.state = state

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -163,7 +163,7 @@ try:
                     u_rating = review[0][1]
 
                     if i == 0:
-                        card = Card(due=x_date)
+                        card = Card(card_id=card_id, due=x_date)
 
                     y_pred_retrievability = card.get_retrievability(x_date)
                     y_retrievability = torch.tensor(
@@ -228,7 +228,7 @@ try:
 
                         # if this is the first review, create the Card object
                         if i == 0:
-                            card = Card(due=review_datetime)
+                            card = Card(card_id=card_id, due=review_datetime)
 
                         # only non-same-day reviews count
                         if (
@@ -322,7 +322,7 @@ try:
 
                         # if this is the first review, create the Card object
                         if i == 0:
-                            card = Card(due=x_date)
+                            card = Card(card_id=card_id, due=x_date)
 
                         # predicted target
                         y_pred_retrievability = card.get_retrievability(x_date)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "5.0.0"
+version = "5.0.1"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -693,3 +693,12 @@ class TestPyFSRS:
         card, review_log = scheduler.review_card(card=card, rating=Rating.Good)
 
         assert str(review_log) == repr(review_log)
+
+    def test_unique_card_ids(self):
+        card_ids = []
+        for i in range(1000):
+            card = Card()
+            card_id = card.card_id
+            card_ids.append(card_id)
+
+        assert len(card_ids) == len(set(card_ids))


### PR DESCRIPTION
New `Card` objects, when created, are assigned a `card_id` correpsonding to the current epoch milliseconds of when the card was created. Unfortunately, when cards are created in a batch like
```python
from fsrs import Card

cards = []
for i in range(100):
    card = Card()
    cards.append(card)
```
there may be `card_id` collisions where two different cards are created within 1ms of eachother and thus incorrectly assigned the same `card_id`.

Currently, to account for this issue, we added a section on batch card creation in the README warning developers to wait `1ms` between creating new `Card` objects to prevent collisions. While this warning may be enough for some, I think that the `card_id` initialization is a bit of a leaky abstraction and could be best solved by preventing collisions on our end rather than on the developer's end.

To fix this, when `card_id` is not specified when creating a new `Card` object, the constructor automatically waits 1ms to prevent a potential next card id collision.

I also now explicitly set `card_id` when creating new `Card` objects in the optimizer so as not to slow it down. I also removed the section warning about batch card creation in the README and bumped the patch number to `5.0.1`.

Let me know if you have any questions 👍