### PR TITLE
Optimizer is now compatible with python3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python-version: ["3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11", "3.12", "3.13"]
 
       steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,6 @@ After cloning this repo, install `fsrs` locally in editable mode along with the 
 pip install -e ".[dev]"
 ```
 
-Note: you may not be able to install all of the `dev` dependencies if you are using python 3.13 or 3.14. If this is causing trouble, consider trying to install the `dev` dependencies in a python 3.10-3.12 environment.
-
 Now you're ready to make changes to files in the `fsrs` directory and see your changes reflected immediately.
 
 ### Pass the checks

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ new_review_log = ReviewLog.from_dict(review_log_dict)
 If you have a collection of `ReviewLog` objects, you can optionally reuse them to compute an optimal set of parameters for the `Scheduler` to make it more accurate at scheduling reviews.
 
 ### Installation
-To install the optimizer, first ensure you're using `python 3.10-3.12`, then run:
+
 ```
 pip install "fsrs[optimizer]"
 ```


### PR DESCRIPTION
pytorch v2.6.0 was [released](https://github.com/pytorch/pytorch/releases/tag/v2.6.0) today and is now compatible with python3.13 meaning that python3.13 users can now use py-fsrs's optimizer.

I modified the optimizer github action to verify that the optimizer is now compatible with python3.13 and also updated the README and CONTRIBUTING to stop suggesting installing the optimizer with python3.10-3.12.

Let me know if you have any questions 👍