### PR TITLE
Compute optimal retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ new_review_log = ReviewLog.from_dict(review_log_dict)
 
 ## Optimizer (optional)
 
-If you have a collection of `ReviewLog` objects, you can optionally reuse them to compute an optimal set of parameters for the `Scheduler` to make it more accurate at scheduling reviews.
+If you have a collection of `ReviewLog` objects, you can optionally reuse them to compute an optimal set of parameters for the `Scheduler` to make it more accurate at scheduling reviews. You can also compute an optimal retention rate to reduce the future workload of your reviews.
 
 ### Installation
 
@@ -182,7 +182,7 @@ If you have a collection of `ReviewLog` objects, you can optionally reuse them t
 pip install "fsrs[optimizer]"
 ```
 
-### Usage
+### Optimize scheduler parameters
 
 ```python
 from fsrs import ReviewLog, Optimizer, Scheduler
@@ -196,11 +196,20 @@ optimizer = Optimizer(review_logs)
 # compute a set of optimized parameters
 optimal_parameters = optimizer.compute_optimal_parameters()
 
-# initialize a new scheduler with the optimized parameters!
-scheduler = Scheduler(parameters=optimal_parameters)
+# initialize a new scheduler with the optimized parameters
+scheduler = Scheduler(optimal_parameters)
 ```
 
-Note: The computed optimal parameters may be slightly different than the parameters computed by Anki for the same set of review logs. This is because the two implementations are slightly different and updated at different times. If you're interested in the official Rust-based Anki implementation, please see [here](https://github.com/open-spaced-repetition/fsrs-rs).
+### Optimize desired retention
+
+```python
+optimal_retention = optimizer.compute_optimal_retention(optimal_parameters)
+
+# initialize a new scheduler with both optimized parameters and retention
+scheduler = Scheduler(optimal_parameters, optimal_retention)
+```
+
+Note: The computed optimal parameters and retention may be slightly different than the numbers computed by Anki for the same set of review logs. This is because the two implementations are slightly different and updated at different times. If you're interested in the official Rust-based Anki implementation, please see [here](https://github.com/open-spaced-repetition/fsrs-rs).
 
 ## Reference
 

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -128,11 +128,6 @@ try:
                         revlogs_train[card_id], key=lambda x: x[0][0]
                     )  # keep reviews sorted
 
-                # convert the timestamps in the json from isoformat to datetime variables
-                for key, values in revlogs_train.items():
-                    for entry in values:
-                        entry[0][0] = datetime.fromisoformat(entry[0][0])
-
                 # sort the dictionary in order of when each card history starts
                 revlogs_train = dict(sorted(revlogs_train.items()))
 

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -10,13 +10,13 @@ import math
 from datetime import datetime, timezone
 from copy import deepcopy
 from random import Random
-import pandas as pd
 from statistics import mean
 
 try:
     import torch
     from torch.nn import BCELoss
     from torch import optim
+    import pandas as pd
 
     # weight clipping
     S_MIN = 0.01

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -399,9 +399,11 @@ try:
                         )
 
             def _compute_probs_and_costs() -> dict[str, float]:
-                df = pd.DataFrame(vars(review_log) for review_log in self.review_logs)
+                review_log_df = pd.DataFrame(
+                    vars(review_log) for review_log in self.review_logs
+                )
 
-                df = df.sort_values(
+                review_log_df = review_log_df.sort_values(
                     by=["card_id", "review_datetime"], ascending=[True, True]
                 ).reset_index(drop=True)
 
@@ -409,8 +411,8 @@ try:
                 probs_and_costs_dict = {}
 
                 # compute the probabilities and costs of the first rating
-                first_reviews_df = df.loc[
-                    ~df["card_id"].duplicated(keep="first")
+                first_reviews_df = review_log_df.loc[
+                    ~review_log_df["card_id"].duplicated(keep="first")
                 ].reset_index(drop=True)
 
                 first_again_reviews_df = first_reviews_df.loc[
@@ -495,8 +497,8 @@ try:
                 )
 
                 # compute the probabilities and costs of non-first ratings
-                non_first_reviews_df = df.loc[
-                    df["card_id"].duplicated(keep="first")
+                non_first_reviews_df = review_log_df.loc[
+                    review_log_df["card_id"].duplicated(keep="first")
                 ].reset_index(drop=True)
 
                 again_reviews_df = non_first_reviews_df.loc[

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -673,7 +673,7 @@ try:
                         )
                         curr_date = card.due
 
-                total_knowledge = desired_retention * NUM_CARDS_SIMULATE
+                total_knowledge = desired_retention * num_cards_simulate
                 simulation_cost = simulation_cost / total_knowledge
 
                 return simulation_cost

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -7,9 +7,11 @@ This module defines the optional Optimizer class.
 
 from .fsrs import Card, ReviewLog, Scheduler, Rating, DEFAULT_PARAMETERS
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 from copy import deepcopy
 from random import Random
+import pandas as pd
+from statistics import mean
 
 try:
     import torch
@@ -385,6 +387,319 @@ try:
                     best_params = detached_params
 
             return best_params
+
+        def compute_optimal_retention(
+            self, parameters: tuple[float, ...] | list[float]
+        ) -> list[float]:
+            def _validate_review_logs() -> None:
+                if len(self.review_logs) < 512:
+                    raise ValueError(
+                        "Not enough ReviewLog's: at least 512 ReviewLog objects are required to compute optimal retention"
+                    )
+
+                for review_log in self.review_logs:
+                    if review_log.review_duration is None:
+                        raise ValueError(
+                            "ReviewLog.review_duration cannot be None when computing optimal retention"
+                        )
+
+            def _compute_probs_and_costs() -> dict[str, float]:
+                df = pd.DataFrame(vars(review_log) for review_log in self.review_logs)
+
+                df = df.sort_values(
+                    by=["card_id", "review_datetime"], ascending=[True, True]
+                ).reset_index(drop=True)
+
+                # dictionary to return
+                probs_and_costs_dict = {}
+
+                # compute the probabilities and costs of the first rating
+                first_reviews_df = df.loc[
+                    ~df["card_id"].duplicated(keep="first")
+                ].reset_index(drop=True)
+
+                first_again_reviews_df = first_reviews_df.loc[
+                    first_reviews_df["rating"] == Rating.Again
+                ]
+                first_hard_reviews_df = first_reviews_df.loc[
+                    first_reviews_df["rating"] == Rating.Hard
+                ]
+                first_good_reviews_df = first_reviews_df.loc[
+                    first_reviews_df["rating"] == Rating.Good
+                ]
+                first_easy_reviews_df = first_reviews_df.loc[
+                    first_reviews_df["rating"] == Rating.Easy
+                ]
+
+                # compute the probability of the user clicking again/hard/good/easy given it's their first review
+                num_first_again = len(first_again_reviews_df)
+                num_first_hard = len(first_hard_reviews_df)
+                num_first_good = len(first_good_reviews_df)
+                num_first_easy = len(first_easy_reviews_df)
+
+                num_first_review = (
+                    num_first_again + num_first_hard + num_first_good + num_first_easy
+                )
+
+                prob_first_again = num_first_again / num_first_review
+                prob_first_hard = num_first_hard / num_first_review
+                prob_first_good = num_first_good / num_first_review
+                prob_first_easy = num_first_easy / num_first_review
+
+                probs_and_costs_dict["prob_first_again"] = prob_first_again
+                probs_and_costs_dict["prob_first_hard"] = prob_first_hard
+                probs_and_costs_dict["prob_first_good"] = prob_first_good
+                probs_and_costs_dict["prob_first_easy"] = prob_first_easy
+
+                # compute the cost of the user clicking again/hard/good/easy on their first review
+                first_again_review_durations = list(
+                    first_again_reviews_df["review_duration"]
+                )
+                first_hard_review_durations = list(
+                    first_hard_reviews_df["review_duration"]
+                )
+                first_good_review_durations = list(
+                    first_good_reviews_df["review_duration"]
+                )
+                first_easy_review_durations = list(
+                    first_easy_reviews_df["review_duration"]
+                )
+
+                avg_first_again_review_duration = (
+                    mean(first_again_review_durations)
+                    if first_again_review_durations
+                    else 0
+                )
+                avg_first_hard_review_duration = (
+                    mean(first_hard_review_durations)
+                    if first_hard_review_durations
+                    else 0
+                )
+                avg_first_good_review_duration = (
+                    mean(first_good_review_durations)
+                    if first_good_review_durations
+                    else 0
+                )
+                avg_first_easy_review_duration = (
+                    mean(first_easy_review_durations)
+                    if first_easy_review_durations
+                    else 0
+                )
+
+                probs_and_costs_dict["avg_first_again_review_duration"] = (
+                    avg_first_again_review_duration
+                )
+                probs_and_costs_dict["avg_first_hard_review_duration"] = (
+                    avg_first_hard_review_duration
+                )
+                probs_and_costs_dict["avg_first_good_review_duration"] = (
+                    avg_first_good_review_duration
+                )
+                probs_and_costs_dict["avg_first_easy_review_duration"] = (
+                    avg_first_easy_review_duration
+                )
+
+                # compute the probabilities and costs of non-first ratings
+                non_first_reviews_df = df.loc[
+                    df["card_id"].duplicated(keep="first")
+                ].reset_index(drop=True)
+
+                again_reviews_df = non_first_reviews_df.loc[
+                    non_first_reviews_df["rating"] == Rating.Again
+                ]
+                hard_reviews_df = non_first_reviews_df.loc[
+                    non_first_reviews_df["rating"] == Rating.Hard
+                ]
+                good_reviews_df = non_first_reviews_df.loc[
+                    non_first_reviews_df["rating"] == Rating.Good
+                ]
+                easy_reviews_df = non_first_reviews_df.loc[
+                    non_first_reviews_df["rating"] == Rating.Easy
+                ]
+
+                # compute the probability of the user clicking hard/good/easy given they correctly recalled the card
+                num_hard = len(hard_reviews_df)
+                num_good = len(good_reviews_df)
+                num_easy = len(easy_reviews_df)
+
+                num_recall = num_hard + num_good + num_easy
+
+                prob_hard = num_hard / num_recall
+                prob_good = num_good / num_recall
+                prob_easy = num_easy / num_recall
+
+                probs_and_costs_dict["prob_hard"] = prob_hard
+                probs_and_costs_dict["prob_good"] = prob_good
+                probs_and_costs_dict["prob_easy"] = prob_easy
+
+                again_review_durations = list(again_reviews_df["review_duration"])
+                hard_review_durations = list(hard_reviews_df["review_duration"])
+                good_review_durations = list(good_reviews_df["review_duration"])
+                easy_review_durations = list(easy_reviews_df["review_duration"])
+
+                avg_again_review_duration = (
+                    mean(again_review_durations) if again_review_durations else 0
+                )
+                avg_hard_review_duration = (
+                    mean(hard_review_durations) if hard_review_durations else 0
+                )
+                avg_good_review_duration = (
+                    mean(good_review_durations) if good_review_durations else 0
+                )
+                avg_easy_review_duration = (
+                    mean(easy_review_durations) if easy_review_durations else 0
+                )
+
+                probs_and_costs_dict["avg_again_review_duration"] = (
+                    avg_again_review_duration
+                )
+                probs_and_costs_dict["avg_hard_review_duration"] = (
+                    avg_hard_review_duration
+                )
+                probs_and_costs_dict["avg_good_review_duration"] = (
+                    avg_good_review_duration
+                )
+                probs_and_costs_dict["avg_easy_review_duration"] = (
+                    avg_easy_review_duration
+                )
+
+                return probs_and_costs_dict
+
+            def _simulate_cost(
+                desired_retention: float, num_cards_simulate: int
+            ) -> float:
+                rng = Random(42)
+
+                # simulate from the beginning of 2025 till before the beginning of 2026
+                start_date = datetime(2025, 1, 1, 0, 0, 0, 0, timezone.utc)
+                end_date = datetime(2026, 1, 1, 0, 0, 0, 0, timezone.utc)
+
+                scheduler = Scheduler(
+                    parameters=parameters,
+                    desired_retention=desired_retention,
+                    enable_fuzzing=False,
+                )
+
+                # unpack probs_and_costs_dict
+                prob_first_again = probs_and_costs_dict["prob_first_again"]
+                prob_first_hard = probs_and_costs_dict["prob_first_hard"]
+                prob_first_good = probs_and_costs_dict["prob_first_good"]
+                prob_first_easy = probs_and_costs_dict["prob_first_easy"]
+
+                avg_first_again_review_duration = probs_and_costs_dict[
+                    "avg_first_again_review_duration"
+                ]
+                avg_first_hard_review_duration = probs_and_costs_dict[
+                    "avg_first_hard_review_duration"
+                ]
+                avg_first_good_review_duration = probs_and_costs_dict[
+                    "avg_first_good_review_duration"
+                ]
+                avg_first_easy_review_duration = probs_and_costs_dict[
+                    "avg_first_easy_review_duration"
+                ]
+
+                prob_hard = probs_and_costs_dict["prob_hard"]
+                prob_good = probs_and_costs_dict["prob_good"]
+                prob_easy = probs_and_costs_dict["prob_easy"]
+
+                avg_again_review_duration = probs_and_costs_dict[
+                    "avg_again_review_duration"
+                ]
+                avg_hard_review_duration = probs_and_costs_dict[
+                    "avg_hard_review_duration"
+                ]
+                avg_good_review_duration = probs_and_costs_dict[
+                    "avg_good_review_duration"
+                ]
+                avg_easy_review_duration = probs_and_costs_dict[
+                    "avg_easy_review_duration"
+                ]
+
+                simulation_cost = 0
+                for i in range(num_cards_simulate):
+                    card = Card()
+                    curr_date = start_date
+                    while curr_date < end_date:
+                        # the card is new
+                        if curr_date == start_date:
+                            rating = rng.choices(
+                                [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy],
+                                weights=[
+                                    prob_first_again,
+                                    prob_first_hard,
+                                    prob_first_good,
+                                    prob_first_easy,
+                                ],
+                            )[0]
+
+                            if rating == Rating.Again:
+                                simulation_cost += avg_first_again_review_duration
+
+                            elif rating == Rating.Hard:
+                                simulation_cost += avg_first_hard_review_duration
+
+                            elif rating == Rating.Good:
+                                simulation_cost += avg_first_good_review_duration
+
+                            elif rating == Rating.Easy:
+                                simulation_cost += avg_first_easy_review_duration
+
+                        # the card is not new
+                        else:
+                            rating = rng.choices(
+                                ["recall", Rating.Again],
+                                weights=[desired_retention, 1.0 - desired_retention],
+                            )[0]
+
+                            if rating == "recall":
+                                # compute probability that the user chose hard/good/easy, GIVEN that they correctly recalled the card
+                                rating = rng.choices(
+                                    [Rating.Hard, Rating.Good, Rating.Easy],
+                                    weights=[prob_hard, prob_good, prob_easy],
+                                )[0]
+
+                            if rating == Rating.Again:
+                                simulation_cost += avg_again_review_duration
+
+                            elif rating == Rating.Hard:
+                                simulation_cost += avg_hard_review_duration
+
+                            elif rating == Rating.Good:
+                                simulation_cost += avg_good_review_duration
+
+                            elif rating == Rating.Easy:
+                                simulation_cost += avg_easy_review_duration
+
+                        card, _ = scheduler.review_card(
+                            card=card, rating=rating, review_datetime=curr_date
+                        )
+                        curr_date = card.due
+
+                total_knowledge = desired_retention * NUM_CARDS_SIMULATE
+                simulation_cost = simulation_cost / total_knowledge
+
+                return simulation_cost
+
+            _validate_review_logs()
+
+            NUM_CARDS_SIMULATE = 1000
+            DESIRED_RETENTIONS = [0.7, 0.75, 0.8, 0.85, 0.9, 0.95]
+
+            probs_and_costs_dict = _compute_probs_and_costs()
+
+            simulation_costs = []
+            for desired_retention in DESIRED_RETENTIONS:
+                simulation_cost = _simulate_cost(
+                    desired_retention=desired_retention,
+                    num_cards_simulate=NUM_CARDS_SIMULATE,
+                )
+                simulation_costs.append(simulation_cost)
+
+            min_index = simulation_costs.index(min(simulation_costs))
+            optimal_retention = DESIRED_RETENTIONS[min_index]
+
+            return optimal_retention
 
 except ImportError:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "5.0.1"
+version = "5.1.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ Homepage = "https://github.com/open-spaced-repetition/py-fsrs"
 
 [project.optional-dependencies]
 dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "poetry"]
-optimizer = ["torch", "numpy"]
+optimizer = ["torch", "numpy", "pandas"]
 
 [tool.pytest.ini_options]
 pythonpath = "."

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from datetime import datetime, timezone
 
+
 def get_revlogs() -> list[ReviewLog]:
     """
     reads a csv of prepared exported anki review logs
@@ -196,30 +197,32 @@ class TestOptimizer:
         )
 
     def test_optimal_retention_zero_review_logs(self):
-
         # can't compute optimal retention with zero review logs
         zero_revlogs = []
         optimizer = Optimizer(zero_revlogs)
         with pytest.raises(ValueError):
-            optimal_retention = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)
+            _ = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)
 
     def test_optimal_retention_few_review_logs(self):
-
         review_logs = get_revlogs()
         few_revlogs = review_logs[:100]
 
         optimizer = Optimizer(few_revlogs)
         with pytest.raises(ValueError):
-            optimal_retention = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)
+            _ = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)
 
     def test_optimal_retention_no_review_duration(self):
-
         review_logs = get_revlogs()
 
-        review_log_without_review_duration = ReviewLog(card_id=42, rating=2, review_datetime=datetime(2025, 1, 1, 0, 0, 0, 0, timezone.utc), review_duration=None)
+        review_log_without_review_duration = ReviewLog(
+            card_id=42,
+            rating=2,
+            review_datetime=datetime(2025, 1, 1, 0, 0, 0, 0, timezone.utc),
+            review_duration=None,
+        )
 
         review_logs.append(review_log_without_review_duration)
 
         optimizer = Optimizer(review_logs)
         with pytest.raises(ValueError):
-            optimal_retention = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)
+            _ = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,9 +1,10 @@
-from fsrs import ReviewLog, Optimizer, DEFAULT_PARAMETERS
+from fsrs import ReviewLog, Optimizer, DEFAULT_PARAMETERS, Rating
 import pandas as pd
 from copy import deepcopy
 from random import shuffle
 import numpy as np
-
+import pytest
+from datetime import datetime, timezone
 
 def get_revlogs() -> list[ReviewLog]:
     """
@@ -193,3 +194,32 @@ class TestOptimizer:
         assert (
             optimal_retention_default_parameters != optimal_retention_optimal_parameters
         )
+
+    def test_optimal_retention_zero_review_logs(self):
+
+        # can't compute optimal retention with zero review logs
+        zero_revlogs = []
+        optimizer = Optimizer(zero_revlogs)
+        with pytest.raises(ValueError):
+            optimal_retention = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)
+
+    def test_optimal_retention_few_review_logs(self):
+
+        review_logs = get_revlogs()
+        few_revlogs = review_logs[:100]
+
+        optimizer = Optimizer(few_revlogs)
+        with pytest.raises(ValueError):
+            optimal_retention = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)
+
+    def test_optimal_retention_no_review_duration(self):
+
+        review_logs = get_revlogs()
+
+        review_log_without_review_duration = ReviewLog(card_id=42, rating=2, review_datetime="2024-03-29T20:32:32.250000+00:00", review_duration=None)
+
+        review_logs.append(review_log_without_review_duration)
+
+        optimizer = Optimizer(review_logs)
+        with pytest.raises(ValueError):
+            optimal_retention = optimizer.compute_optimal_retention(parameters=DEFAULT_PARAMETERS)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -138,3 +138,58 @@ class TestOptimizer:
         optimal_parameters2 = optimizer2.compute_optimal_parameters()
 
         assert optimal_parameters1 == optimal_parameters2
+
+    def test_optimal_retention(self):
+        review_logs = get_revlogs()
+
+        optimizer = Optimizer(review_logs)
+
+        expected_optimal_retention = 0.85
+
+        optimal_parameters = [
+            0.2363282014982659,
+            1.18385,
+            2.803907798259358,
+            15.69105,
+            7.450626954515589,
+            0.2002981626622733,
+            1.6499680903504104,
+            0.030489930904182852,
+            1.3726592620867732,
+            0.20407416745070098,
+            0.9003453768459656,
+            2.0169172501722157,
+            0.05052109238927132,
+            0.249798385275728,
+            2.3878771773930296,
+            0.47499255667044843,
+            2.9898,
+            0.19075214884576136,
+            1.0712483452116681,
+        ]
+
+        optimal_retention_optimal_parameters = optimizer.compute_optimal_retention(
+            parameters=optimal_parameters
+        )
+
+        # deterministic outcome
+        assert optimal_retention_optimal_parameters == expected_optimal_retention
+
+        # computing the optimal retention on a new optimizer with the same review logs and parameters will return
+        # the same result
+        optimizer_2 = Optimizer(review_logs)
+        optimal_retention_optimal_parameters_2 = optimizer_2.compute_optimal_retention(
+            parameters=optimal_parameters
+        )
+        assert (
+            optimal_retention_optimal_parameters_2
+            == optimal_retention_optimal_parameters
+        )
+
+        # computing the optimal retention with a different set of parameters can yield a different result
+        optimal_retention_default_parameters = optimizer_2.compute_optimal_retention(
+            parameters=DEFAULT_PARAMETERS
+        )
+        assert (
+            optimal_retention_default_parameters != optimal_retention_optimal_parameters
+        )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -17,8 +17,8 @@ def get_revlogs() -> list[ReviewLog]:
     review_logs = []
     for index, row in df.iterrows():
         card_id = row["card_id"]
-        rating = row["review_rating"]
-        review_datetime = row["review_time"]
+        rating = Rating(row["review_rating"])
+        review_datetime = datetime.fromisoformat(row["review_time"])
         review_duration = row["review_duration"]
 
         review_log = ReviewLog(
@@ -216,7 +216,7 @@ class TestOptimizer:
 
         review_logs = get_revlogs()
 
-        review_log_without_review_duration = ReviewLog(card_id=42, rating=2, review_datetime="2024-03-29T20:32:32.250000+00:00", review_duration=None)
+        review_log_without_review_duration = ReviewLog(card_id=42, rating=2, review_datetime=datetime(2025, 1, 1, 0, 0, 0, 0, timezone.utc), review_duration=None)
 
         review_logs.append(review_log_without_review_duration)
 


### PR DESCRIPTION
I added a `compute_optimal_retention` method to the `Optimizer` class which estimates an optimal `desired_retention` rate for the `Scheduler` by simulating the cost of reviewing cards at various different levels of retention. Specifically, it simulates the following fixed retention rates `[0.7, 0.75, 0.8, 0.85, 0.9, 0.95]` and chooses the most optimal one, basically like a 'grid search'. After much experimentation with Brent's method, I decided that a grid search would be both more efficient and accurate since Brent's method takes longer and unfortunately more frequently gets stuck at local minima given the stochastic (and thus non-convex) nature of the simulations.

I also did the following:
1. Added `pandas` to the optional `optimizer` dependencies
2. Added more unit tests
3. Updated the `README` to mention the optional retention calculator
4. Fixed a datetime bug in the Optimizer
5. Bumped the minor version to `5.1.0`

Let me know if you have any questions 👍