### PR TITLE
Fix multiple schedulers edge case

### DIFF
--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -447,9 +447,9 @@ class Scheduler:
 
             # calculate the card's next interval
             # len(self.learning_steps) == 0: no learning steps defined so move card to Review state
-            # card.step > len(self.learning_steps): handles the edge-case when a card was originally scheduled with a scheduler with more
+            # card.step >= len(self.learning_steps): handles the edge-case when a card was originally scheduled with a scheduler with more
             # learning steps than the current scheduler
-            if len(self.learning_steps) == 0 or card.step > len(self.learning_steps):
+            if len(self.learning_steps) == 0 or card.step >= len(self.learning_steps):
                 card.state = State.Review
                 card.step = None
 
@@ -559,9 +559,9 @@ class Scheduler:
 
             # calculate the card's next interval
             # len(self.relearning_steps) == 0: no relearning steps defined so move card to Review state
-            # card.step > len(self.relearning_steps): handles the edge-case when a card was originally scheduled with a scheduler with more
+            # card.step >= len(self.relearning_steps): handles the edge-case when a card was originally scheduled with a scheduler with more
             # relearning steps than the current scheduler
-            if len(self.relearning_steps) == 0 or card.step > len(
+            if len(self.relearning_steps) == 0 or card.step >= len(
                 self.relearning_steps
             ):
                 card.state = State.Review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "5.1.0"
+version = "5.1.1"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -603,7 +603,20 @@ class TestPyFSRS:
         scheduler_with_two_learning_steps = Scheduler(
             learning_steps=(timedelta(minutes=1), timedelta(minutes=10))
         )
-        scheduler_with_no_learning_steps = Scheduler(learning_steps=())
+        scheduler_with_one_learning_step = Scheduler(
+            learning_steps=(timedelta(minutes=1),)
+        )
+
+        scheduler_with_two_relearning_steps = Scheduler(
+            relearning_steps=(
+                timedelta(minutes=1),
+                timedelta(minutes=10),
+            )
+        )
+        scheduler_with_one_relearning_step = Scheduler(
+            relearning_steps=(timedelta(minutes=1),)
+        )
+        scheduler_with_no_relearning_steps = Scheduler(relearning_steps=())
 
         card = Card()
 
@@ -614,23 +627,14 @@ class TestPyFSRS:
         assert card.state == State.Learning
         assert card.step == 1
 
-        assert len(scheduler_with_no_learning_steps.learning_steps) == 0
-        card, _ = scheduler_with_no_learning_steps.review_card(
+        assert len(scheduler_with_one_learning_step.learning_steps) == 1
+        card, _ = scheduler_with_one_learning_step.review_card(
             card=card, rating=Rating.Again, review_datetime=datetime.now(timezone.utc)
         )
         assert card.state == State.Review
         assert card.step is None
 
-        scheduler_with_two_relearning_steps = Scheduler(
-            relearning_steps=(
-                timedelta(minutes=1),
-                timedelta(minutes=10),
-                timedelta(minutes=15),
-            )
-        )
-        scheduler_with_no_relearning_steps = Scheduler(relearning_steps=())
-
-        assert len(scheduler_with_two_relearning_steps.relearning_steps) == 3
+        assert len(scheduler_with_two_relearning_steps.relearning_steps) == 2
         card, _ = scheduler_with_two_relearning_steps.review_card(
             card=card, rating=Rating.Again, review_datetime=datetime.now(timezone.utc)
         )
@@ -643,11 +647,11 @@ class TestPyFSRS:
         assert card.state == State.Relearning
         assert card.step == 1
 
-        card, _ = scheduler_with_two_relearning_steps.review_card(
-            card=card, rating=Rating.Good, review_datetime=datetime.now(timezone.utc)
+        card, _ = scheduler_with_one_relearning_step.review_card(
+            card=card, rating=Rating.Again, review_datetime=datetime.now(timezone.utc)
         )
-        assert card.state == State.Relearning
-        assert card.step == 2
+        assert card.state == State.Review
+        assert card.step is None
 
         card, _ = scheduler_with_no_relearning_steps.review_card(
             card=card, rating=Rating.Again, review_datetime=datetime.now(timezone.utc)


### PR DESCRIPTION
It was brought to my attention in #89 that the edge case of a single `Card` being scheduled with multiple `Scheduler` objects with variable numbers of re/learning steps was not being handled correctly and that this was not being picked up because there was an issue with one of the unit tests.

I went and fixed the edge case handling and also fixed the unit test. And then I also bumped the patch from `5.1.0` to `5.1.1`

Let me know if you have any questions 👍