### PR TITLE
Fix handling of multiple schedulers edge case

### DIFF
--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -446,10 +446,12 @@ class Scheduler:
                 )
 
             # calculate the card's next interval
-            # len(self.learning_steps) == 0: no learning steps defined so move card to Review state
-            # card.step >= len(self.learning_steps): handles the edge-case when a card was originally scheduled with a scheduler with more
-            # learning steps than the current scheduler
-            if len(self.learning_steps) == 0 or card.step >= len(self.learning_steps):
+            ## first if-clause handles edge case where the Card in the Learning state was previously
+            ## scheduled with a Scheduler with more learning_steps than the current Scheduler
+            if len(self.learning_steps) == 0 or (
+                card.step >= len(self.learning_steps)
+                and rating in (Rating.Hard, Rating.Good, Rating.Easy)
+            ):
                 card.state = State.Review
                 card.step = None
 
@@ -558,11 +560,11 @@ class Scheduler:
                 )
 
             # calculate the card's next interval
-            # len(self.relearning_steps) == 0: no relearning steps defined so move card to Review state
-            # card.step >= len(self.relearning_steps): handles the edge-case when a card was originally scheduled with a scheduler with more
-            # relearning steps than the current scheduler
-            if len(self.relearning_steps) == 0 or card.step >= len(
-                self.relearning_steps
+            ## first if-clause handles edge case where the Card in the Relearning state was previously
+            ## scheduled with a Scheduler with more relearning_steps than the current Scheduler
+            if len(self.relearning_steps) == 0 or (
+                card.step >= len(self.relearning_steps)
+                and rating in (Rating.Hard, Rating.Good, Rating.Easy)
             ):
                 card.state = State.Review
                 card.step = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "5.1.1"
+version = "5.1.2"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Previously, in the edge case where a `Card` in the `Learning` state was scheduled with a new `Scheduler` with fewer `learning_steps` than the `Card`'s current `step`, the `Card` would be moved to the `Review` state after being reviewed, regardless of the chosen rating. 

For example:

```python
from fsrs import Scheduler, Card, Rating
from datetime import timedelta

scheduler_with_three_learning_steps = Scheduler(
    learning_steps=(timedelta(minutes=1), timedelta(minutes=5), timedelta(minutes=10))
)
scheduler_with_one_learning_step = Scheduler(
    learning_steps=(timedelta(minutes=1),)
)

card = Card()

print(card.state.name)
print(card.step)
# > Learning
# > 0

card, _ = scheduler_with_three_learning_steps.review_card(card, Rating.Good)
card, _ = scheduler_with_three_learning_steps.review_card(card, Rating.Good)

print(card.state.name)
print(card.step)
# > Learning
# > 2

# (switch scheduler)
card, _ = scheduler_with_one_learning_step.review_card(card, Rating.Again)
print(card.state.name)
print(card.step)
# > Review
# > None
```

However, as was mentioned in this [comment](https://github.com/open-spaced-repetition/py-fsrs/pull/90#issuecomment-2644194116), in an example like the one above, it would make more sense if the `Card` were to stay in the `Learning` state and move back to `step=0` rather than move to the `Review` state.

Example with fix:
```python
card = Card()

print(card.state.name)
print(card.step)
# > Learning
# > 0

card, _ = scheduler_with_three_learning_steps.review_card(card, Rating.Good)
card, _ = scheduler_with_three_learning_steps.review_card(card, Rating.Good)

print(card.state.name)
print(card.step)
# > Learning
# > 2

# (switch scheduler)
card, _ = scheduler_with_one_learning_step.review_card(card, Rating.Again)
print(card.state.name)
print(card.step)
# > Learning
# > 0
```

I went and did the following:
- I changed the scheduler's handling of this edge case for both learning and relearning states
- I adjusted the unit tests to account for this change
- I bumped the patch from 5.1.1 -> 5.1.2

Let me know if you have any questions