### PR TITLE
Bring Py-FSRS up to recommended community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Report a bug and provide reproduction steps
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Which version of py-fsrs?**
+
+<!-- specify which version of py-fsrs you're using -->
+
+**Bug description:**
+
+<!-- describe the bug here -->
+
+**Steps to reproduce the bug:**
+
+<!-- provide a minimum code example to reproduce the bug -->
+
+```python
+
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: Questions
+      url: https://github.com/open-spaced-repetition/py-fsrs/discussions
+      about: Please ask general questions here instead of opening an issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+<!--If this PR resolves an issue, link its number below. Otherwise, delete the line.-->
+Closes #ISSUE_NUMBER

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Always be respectful, assume good intent and try to stay on topic as much as possible.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+## Supported versions
+
+Only the latest version of py-fsrs will be supported with security updates. You can find the lastest version of py-fsrs [here](https://github.com/open-spaced-repetition/py-fsrs/releases/latest).
+
+## Reporting a security vulnerability
+
+If you find a security vulnerability with py-fsrs, we'd like to know!
+
+For non-severe vulnerabilites, please just open a normal [issue](https://github.com/open-spaced-repetition/py-fsrs/issues).
+
+For more severe security vulnerabilities, please report it [here](https://github.com/open-spaced-repetition/py-fsrs/security/advisories/new).


### PR DESCRIPTION
I was thinking it'd be a good idea to bring py-fsrs up to github's recommended community standards. See [here](https://github.com/open-spaced-repetition/py-fsrs/community).

To do this, I
- Added a code of conduct
- Added a security policy
- Added an issue template when creating new issues
- Added a PR template for new pr's.

Overall, I tried to make these policies and templates pretty minimal so they don't get in the way.

Lmk if you have any questions