### PR TITLE
FSRS 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,26 +97,28 @@ from datetime import timedelta
 # note: the following arguments are also the defaults
 scheduler = Scheduler(
     parameters = (
-            0.40255,
-            1.18385,
-            3.173,
-            15.69105,
-            7.1949,
-            0.5345,
-            1.4604,
-            0.0046,
-            1.54575,
-            0.1192,
-            1.01925,
-            1.9395,
-            0.11,
-            0.29605,
-            2.2698,
-            0.2315,
-            2.9898,
-            0.51655,
-            0.6621,
-        ),
+            0.2172,
+            1.1771,
+            3.2602,
+            16.1507,
+            7.0114,
+            0.57,
+            2.0966,
+            0.0069,
+            1.5261,
+            0.112,
+            1.0178,
+            1.849,
+            0.1133,
+            0.3127,
+            2.2934,
+            0.2191,
+            3.0004,
+            0.7536,
+            0.3332,
+            0.1437,
+            0.2,
+    ),
     desired_retention = 0.9,
     learning_steps = (timedelta(minutes=1), timedelta(minutes=10)),
     relearning_steps = (timedelta(minutes=10),),
@@ -127,7 +129,7 @@ scheduler = Scheduler(
 
 #### Explanation of parameters
 
-`parameters` are a set of 19 model weights that affect how the FSRS scheduler will schedule future reviews. If you're not familiar with optimizing FSRS, it is best not to modify these default values.
+`parameters` are a set of 21 model weights that affect how the FSRS scheduler will schedule future reviews. If you're not familiar with optimizing FSRS, it is best not to modify these default values.
 
 `desired_retention` is a value between 0 and 1 that sets the desired minimum retention rate for cards when scheduled with the scheduler. For example, with the default value of `desired_retention=0.9`, a card will be scheduled at a time in the future when the predicted probability of the user correctly recalling that card falls to 90%. A higher `desired_retention` rate will lead to more reviews and a lower rate will lead to fewer reviews.
 
@@ -150,7 +152,7 @@ You can still specify custom datetimes, but they must use the UTC timezone.
 You can calculate the current probability of correctly recalling a card (its 'retrievability') with
 
 ```python
-retrievability = card.get_retrievability()
+retrievability = scheduler.get_card_retrievability(card)
 
 print(f"There is a {retrievability} probability that this card is remembered.")
 # > There is a 0.94 probability that this card is remembered.

--- a/fsrs/__init__.py
+++ b/fsrs/__init__.py
@@ -12,6 +12,7 @@ from .fsrs import (
     ReviewLog,
     State,
     DEFAULT_PARAMETERS,
+    STABILITY_MIN,
 )
 
 from .optimizer import Optimizer
@@ -24,4 +25,5 @@ __all__ = [
     "State",
     "Optimizer",
     "DEFAULT_PARAMETERS",
+    "STABILITY_MIN",
 ]

--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -20,6 +20,8 @@ from enum import IntEnum
 from random import random
 import time
 
+STABILITY_MIN = 0.001
+
 DEFAULT_PARAMETERS = (
     0.2172,
     1.1771,
@@ -703,9 +705,9 @@ class Scheduler:
 
     def _clamp_stability(self, stability: float) -> float:
         if isinstance(stability, (float, int)):
-            stability = max(stability, 0.01)
+            stability = max(stability, STABILITY_MIN)
         else:  # type(stability) is torch.Tensor
-            stability = stability.clamp(min=0.01)
+            stability = stability.clamp(min=STABILITY_MIN)
 
         return stability
 

--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -739,11 +739,19 @@ class Scheduler:
         return next_interval
 
     def _short_term_stability(self, stability: float, rating: Rating) -> float:
-        short_term_stability = (
-            stability
-            * (math.e ** (self.parameters[17] * (rating - 3 + self.parameters[18])))
-            * (stability ** -self.parameters[19])
-        )
+        short_term_stability_increase = (
+            math.e ** (self.parameters[17] * (rating - 3 + self.parameters[18]))
+        ) * (stability ** -self.parameters[19])
+
+        if rating in (Rating.Good, Rating.Easy):
+            if isinstance(short_term_stability_increase, (float, int)):
+                short_term_stability_increase = max(short_term_stability_increase, 1.0)
+            else:  # type(short_term_stability_increase) is torch.Tensor
+                short_term_stability_increase = short_term_stability_increase.clamp(
+                    min=1.0
+                )
+
+        short_term_stability = stability * short_term_stability_increase
 
         short_term_stability = self._clamp_stability(short_term_stability)
 

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -42,6 +42,8 @@ try:
             1.0,
             0.0,
             0.0,
+            0.0,
+            0.1,
         ],
         dtype=torch.float64,
     )
@@ -66,6 +68,8 @@ try:
             6.0,
             2.0,
             2.0,
+            0.8,
+            0.8,
         ],
         dtype=torch.float64,
     )
@@ -162,7 +166,9 @@ try:
                     if i == 0:
                         card = Card(card_id=card_id, due=x_date)
 
-                    y_pred_retrievability = card.get_retrievability(x_date)
+                    y_pred_retrievability = card.get_retrievability(
+                        scheduler_parameters=params, current_datetime=x_date
+                    )
                     y_retrievability = torch.tensor(
                         y_retrievability, dtype=torch.float64
                     )
@@ -322,7 +328,9 @@ try:
                             card = Card(card_id=card_id, due=x_date)
 
                         # predicted target
-                        y_pred_retrievability = card.get_retrievability(x_date)
+                        y_pred_retrievability = card.get_retrievability(
+                            scheduler_parameters=params, current_datetime=x_date
+                        )
                         y_retrievability = torch.tensor(
                             y_retrievability, dtype=torch.float64
                         )

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -5,7 +5,7 @@ fsrs.optimizer
 This module defines the optional Optimizer class.
 """
 
-from .fsrs import Card, ReviewLog, Scheduler, Rating, DEFAULT_PARAMETERS
+from .fsrs import Card, ReviewLog, Scheduler, Rating, DEFAULT_PARAMETERS, STABILITY_MIN
 import math
 from datetime import datetime, timezone
 from copy import deepcopy
@@ -18,15 +18,14 @@ try:
     from torch import optim
     import pandas as pd
 
-    # weight clipping
-    S_MIN = 0.01
+    # weight clipping   
     INIT_S_MAX = 100.0
     lower_bounds = torch.tensor(
         [
-            S_MIN,
-            S_MIN,
-            S_MIN,
-            S_MIN,
+            STABILITY_MIN,
+            STABILITY_MIN,
+            STABILITY_MIN,
+            STABILITY_MIN,
             1.0,
             0.1,
             0.1,

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -18,7 +18,7 @@ try:
     from torch import optim
     import pandas as pd
 
-    # weight clipping   
+    # weight clipping
     INIT_S_MAX = 100.0
     lower_bounds = torch.tensor(
         [
@@ -165,8 +165,8 @@ try:
                     if i == 0:
                         card = Card(card_id=card_id, due=x_date)
 
-                    y_pred_retrievability = card.get_retrievability(
-                        scheduler_parameters=params, current_datetime=x_date
+                    y_pred_retrievability = scheduler.get_card_retrievability(
+                        card=card, current_datetime=x_date
                     )
                     y_retrievability = torch.tensor(
                         y_retrievability, dtype=torch.float64
@@ -327,8 +327,8 @@ try:
                             card = Card(card_id=card_id, due=x_date)
 
                         # predicted target
-                        y_pred_retrievability = card.get_retrievability(
-                            scheduler_parameters=params, current_datetime=x_date
+                        y_pred_retrievability = scheduler.get_card_retrievability(
+                            card=card, current_datetime=x_date
                         )
                         y_retrievability = torch.tensor(
                             y_retrievability, dtype=torch.float64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "5.1.4"
+version = "6.0.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,4 @@
-from fsrs import Scheduler, Card, ReviewLog, State, Rating
+from fsrs import Scheduler, Card, ReviewLog, State, Rating, STABILITY_MIN
 from datetime import datetime, timedelta, timezone
 import json
 import pytest
@@ -746,7 +746,7 @@ class TestPyFSRS:
 
     def test_stability_lower_bound(self):
         """
-        Ensure that a Card object's stability is always >= 0.01
+        Ensure that a Card object's stability is always >= STABILITY_MIN
         """
 
         scheduler = Scheduler()
@@ -759,4 +759,4 @@ class TestPyFSRS:
                 rating=Rating.Again,
                 review_datetime=card.due + timedelta(days=1),
             )
-            assert card.stability >= 0.01
+            assert card.stability >= STABILITY_MIN

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -43,16 +43,16 @@ class TestPyFSRS:
             0,
             4,
             14,
-            44,
-            125,
-            328,
+            45,
+            135,
+            372,
             0,
             0,
-            7,
-            16,
-            34,
-            71,
-            142,
+            2,
+            5,
+            10,
+            20,
+            40,
         ]
 
     def test_repeated_correct_reviews(self):
@@ -97,8 +97,8 @@ class TestPyFSRS:
             card=card, rating=Rating.Good, review_datetime=review_datetime
         )
 
-        assert round(card.stability) == 49
-        assert round(card.difficulty, 4) == 7.0866
+        assert round(card.stability, 4) == 50.5655
+        assert round(card.difficulty, 4) == 6.8271
 
     def test_repeat_default_arg(self):
         scheduler = Scheduler()
@@ -259,7 +259,21 @@ class TestPyFSRS:
             ivl_history.append(ivl)
             now = card.due
 
-        assert ivl_history == [0, 4, 14, 44, 125, 328, 0, 0, 7, 16, 34, 71, 142]
+        assert ivl_history == [
+            0,
+            4,
+            14,
+            45,
+            135,
+            372,
+            0,
+            0,
+            2,
+            5,
+            10,
+            20,
+            40,
+        ]
 
         # initialize another scheduler and verify parameters are properly set
         parameters2 = (
@@ -282,6 +296,8 @@ class TestPyFSRS:
             2.8755,
             1.234,
             5.6789,
+            0.1437,
+            0.2,
         )
         desired_retention2 = 0.85
         maximum_interval2 = 3650
@@ -297,30 +313,39 @@ class TestPyFSRS:
 
     def test_retrievability(self):
         scheduler = Scheduler()
+        scheduler_parameters = scheduler.parameters
 
         card = Card()
 
         # retrievabiliy of New card
         assert card.state == State.Learning
-        retrievability = card.get_retrievability()
+        retrievability = card.get_retrievability(
+            scheduler_parameters=scheduler_parameters
+        )
         assert retrievability == 0
 
         # retrievabiliy of Learning card
         card, _ = scheduler.review_card(card, Rating.Good)
         assert card.state == State.Learning
-        retrievability = card.get_retrievability()
+        retrievability = card.get_retrievability(
+            scheduler_parameters=scheduler_parameters
+        )
         assert 0 <= retrievability <= 1
 
         # retrievabiliy of Review card
         card, _ = scheduler.review_card(card, Rating.Good)
         assert card.state == State.Review
-        retrievability = card.get_retrievability()
+        retrievability = card.get_retrievability(
+            scheduler_parameters=scheduler_parameters
+        )
         assert 0 <= retrievability <= 1
 
         # retrievabiliy of Relearning card
         card, _ = scheduler.review_card(card, Rating.Again)
         assert card.state == State.Relearning
-        retrievability = card.get_retrievability()
+        retrievability = card.get_retrievability(
+            scheduler_parameters=scheduler_parameters
+        )
         assert 0 <= retrievability <= 1
 
     def test_Scheduler_serialize(self):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -87,17 +87,16 @@ class TestPyFSRS:
         review_datetime = datetime(2022, 11, 29, 12, 30, 0, 0, timezone.utc)
 
         for rating, ivl in zip(ratings, ivl_history):
+            review_datetime += timedelta(days=ivl)
             card, _ = scheduler.review_card(
                 card=card, rating=rating, review_datetime=review_datetime
             )
-
-            review_datetime += timedelta(days=ivl)
 
         card, _ = scheduler.review_card(
             card=card, rating=Rating.Good, review_datetime=review_datetime
         )
 
-        assert round(card.stability, 4) == 50.5655
+        assert round(card.stability, 4) == 49.4472
         assert round(card.difficulty, 4) == 6.8271
 
     def test_repeat_default_arg(self):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -313,39 +313,30 @@ class TestPyFSRS:
 
     def test_retrievability(self):
         scheduler = Scheduler()
-        scheduler_parameters = scheduler.parameters
 
         card = Card()
 
         # retrievabiliy of New card
         assert card.state == State.Learning
-        retrievability = card.get_retrievability(
-            scheduler_parameters=scheduler_parameters
-        )
+        retrievability = scheduler.get_card_retrievability(card=card)
         assert retrievability == 0
 
         # retrievabiliy of Learning card
         card, _ = scheduler.review_card(card, Rating.Good)
         assert card.state == State.Learning
-        retrievability = card.get_retrievability(
-            scheduler_parameters=scheduler_parameters
-        )
+        retrievability = scheduler.get_card_retrievability(card=card)
         assert 0 <= retrievability <= 1
 
         # retrievabiliy of Review card
         card, _ = scheduler.review_card(card, Rating.Good)
         assert card.state == State.Review
-        retrievability = card.get_retrievability(
-            scheduler_parameters=scheduler_parameters
-        )
+        retrievability = scheduler.get_card_retrievability(card=card)
         assert 0 <= retrievability <= 1
 
         # retrievabiliy of Relearning card
         card, _ = scheduler.review_card(card, Rating.Again)
         assert card.state == State.Relearning
-        retrievability = card.get_retrievability(
-            scheduler_parameters=scheduler_parameters
-        )
+        retrievability = scheduler.get_card_retrievability(card=card)
         assert 0 <= retrievability <= 1
 
     def test_Scheduler_serialize(self):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -8,27 +8,27 @@ from datetime import datetime, timezone, timedelta
 
 
 test_optimal_parameters = [
-    0.07383554398588515,
+    0.07187394297471637,
     1.1771,
-    3.021798875749096,
+    3.0169121696553542,
     16.1507,
-    7.31242022073767,
-    0.31029525802606056,
-    2.1352729956069685,
-    0.027425894203219506,
-    1.3694037365905216,
-    0.032042900000837114,
-    0.8869474250170448,
-    1.8587169395524872,
-    0.08730347285406886,
-    0.2748618041849032,
-    2.346022042635344,
-    0.4564706585552742,
+    7.314356745620026,
+    0.30949419455338884,
+    2.134560108286105,
+    0.027879349179119314,
+    1.3684683980783474,
+    0.034234971711026685,
+    0.8860983859328975,
+    1.8557965281402204,
+    0.09081887255537589,
+    0.2737123583200299,
+    2.343598989308412,
+    0.4570005358296726,
     3.0004,
-    0.7801721275005318,
-    0.31557964314094267,
-    0.24436545987892708,
-    0.5831250998540343,
+    0.7783101458784651,
+    0.3170397068855834,
+    0.24507686794021452,
+    0.5846431556206967,
 ]
 
 
@@ -243,7 +243,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_75) == 249471
+        assert round(simulation_cost_0_75) == 249258
 
         simulation_cost_0_85 = optimizer._simulate_cost(
             desired_retention=0.85,
@@ -252,7 +252,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_85) == 210800
+        assert round(simulation_cost_0_85) == 209497
 
         simulation_cost_0_95 = optimizer._simulate_cost(
             desired_retention=0.95,
@@ -261,7 +261,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_95) == 258265
+        assert round(simulation_cost_0_95) == 256895
 
         # holds true for these specific revlogs
         assert simulation_cost_0_85 <= simulation_cost_0_75

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -8,27 +8,27 @@ from datetime import datetime, timezone, timedelta
 
 
 test_optimal_parameters = [
-    0.08507233095207588,
+    0.07383554398588515,
     1.1771,
-    2.947485038776238,
+    3.021798875749096,
     16.1507,
-    7.327286095943703,
-    0.3154129821734779,
-    2.1226058374285266,
-    0.027381727356617622,
-    1.367701043447835,
-    0.022451392117455903,
-    0.8821909926756148,
-    1.8526266991419775,
-    0.09465860203075946,
-    0.26982836208004,
-    2.349803259748898,
-    0.4572741007986036,
+    7.31242022073767,
+    0.31029525802606056,
+    2.1352729956069685,
+    0.027425894203219506,
+    1.3694037365905216,
+    0.032042900000837114,
+    0.8869474250170448,
+    1.8587169395524872,
+    0.08730347285406886,
+    0.2748618041849032,
+    2.346022042635344,
+    0.4564706585552742,
     3.0004,
-    0.8704313359333086,
-    0.3465313252586688,
-    0.23185020660132227,
-    0.5648747460223619,
+    0.7801721275005318,
+    0.31557964314094267,
+    0.24436545987892708,
+    0.5831250998540343,
 ]
 
 
@@ -243,7 +243,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_75) == 248041
+        assert round(simulation_cost_0_75) == 249471
 
         simulation_cost_0_85 = optimizer._simulate_cost(
             desired_retention=0.85,
@@ -252,7 +252,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_85) == 205430
+        assert round(simulation_cost_0_85) == 210800
 
         simulation_cost_0_95 = optimizer._simulate_cost(
             desired_retention=0.95,
@@ -261,7 +261,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_95) == 253739
+        assert round(simulation_cost_0_95) == 258265
 
         # holds true for these specific revlogs
         assert simulation_cost_0_85 <= simulation_cost_0_75

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -8,25 +8,27 @@ from datetime import datetime, timezone, timedelta
 
 
 test_optimal_parameters = [
-    0.20225927947936412,
-    1.18385,
-    2.684260177947366,
-    15.69105,
-    7.48737482947971,
-    0.23578139518168015,
-    1.6644599025925886,
-    0.036665405088206725,
-    1.3676206874530776,
-    0.09390688502404983,
-    0.8787434551268416,
-    1.998754670417471,
-    0.043139549890615275,
-    0.22938131117027233,
-    2.4321173858967726,
-    0.4731086903552861,
-    2.9898,
-    0.2932543856796362,
-    1.1289805881063713,
+    0.08507233095207588,
+    1.1771,
+    2.947485038776238,
+    16.1507,
+    7.327286095943703,
+    0.3154129821734779,
+    2.1226058374285266,
+    0.027381727356617622,
+    1.367701043447835,
+    0.022451392117455903,
+    0.8821909926756148,
+    1.8526266991419775,
+    0.09465860203075946,
+    0.26982836208004,
+    2.349803259748898,
+    0.4572741007986036,
+    3.0004,
+    0.8704313359333086,
+    0.3465313252586688,
+    0.23185020660132227,
+    0.5648747460223619,
 ]
 
 
@@ -86,7 +88,7 @@ class TestOptimizer:
         # the optimal paramaters are no longer equal to the starting parameters
         assert optimal_parameters != list(DEFAULT_PARAMETERS)
 
-        # the output is expected
+        # the output is expected and deterministic
         assert np.allclose(optimal_parameters, test_optimal_parameters)
 
         # the computed loss with the optimized parameters are less than that of the starting parameters
@@ -168,12 +170,33 @@ class TestOptimizer:
         )
 
         # computing the optimal retention with a different set of parameters can yield a different result
-        optimal_retention_default_parameters = optimizer_2.compute_optimal_retention(
-            parameters=DEFAULT_PARAMETERS
+        parameters_2 = [
+            0.01,
+            0.01,
+            0.01,
+            0.01,
+            1.0,
+            0.1,
+            0.1,
+            0.0,
+            0.0,
+            0.0,
+            0.01,
+            0.1,
+            0.01,
+            0.01,
+            0.01,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.1,
+        ]
+        optimal_retention_parameters_2 = optimizer_2.compute_optimal_retention(
+            parameters=parameters_2
         )
-        assert (
-            optimal_retention_default_parameters != optimal_retention_optimal_parameters
-        )
+        assert optimal_retention_parameters_2 != optimal_retention_optimal_parameters
 
     def test_optimal_retention_zero_review_logs(self):
         # can't compute optimal retention with zero review logs
@@ -220,7 +243,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_75) == 224315
+        assert round(simulation_cost_0_75) == 248041
 
         simulation_cost_0_85 = optimizer._simulate_cost(
             desired_retention=0.85,
@@ -229,7 +252,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_85) == 205312
+        assert round(simulation_cost_0_85) == 205430
 
         simulation_cost_0_95 = optimizer._simulate_cost(
             desired_retention=0.95,
@@ -238,7 +261,7 @@ class TestOptimizer:
             probs_and_costs_dict=probs_and_costs_dict,
         )
 
-        assert round(simulation_cost_0_95) == 279661
+        assert round(simulation_cost_0_95) == 253739
 
         # holds true for these specific revlogs
         assert simulation_cost_0_85 <= simulation_cost_0_75


### PR DESCRIPTION
This PR upgrades py-fsrs from using the FSRS 5 model to using the FSRS 6 model. In doing so, this PR makes two breaking changes and also updates the unit tests.

To update to FSRS 6, I did the following:
- Updated the default parameters to the new 21 default FSRS 6 parameters
- Updated the short term stability function
- And updated the forgetting curve function

I also made slight changes in the optimizer and unit tests so that they're compatible with FSRS 6.

As for the breaking changes, there are two:
1. Developers now need to specify 21 parameters to the `Scheduler` object rather than 19 like in FSRS 5
2. Developers must also now pass the sheduler's parameters to the `Card.get_retrievability()` method if they'd like to calculate a card object's retrievability.

@L-M-Sherlock I would like some feedback regarding 2)...

Previously, in FSRS 5, you could compute a `Card` object's retrievability like so:
```python
retrievability = card.get_retrievability(some_datetime)
```

but now, since the forgetting curve is modelled with the $w_{20}$ parameter, I changed the API to be like this:
```python
retrievability = card.get_retrievability(scheduler_parameters, some_datetime)
```

I'd just like to have your thoughts on this API design. I'd ideally like to keep calculating a card's retrievability part of the public API and not just used internally when computing intervals or computing errors in the optimizer so I think it should be developer-friendly.

I currently have three ideas on how developers can compute a card's retrievability now that a scheduler parameter is required.

Idea 1: Keep the previous `Card.get_retrivability()` method, but pass the scheduler's parameters to it.

This is what I showed above. The pros would be that this API would be similar to the previous py-fsrs API and also that, by passing all of the scheduler parameters, the developer is doesn't need to worry about the details of which parameter is used in the calculation. It also allows us to potentially add more scheduler parameters to the forgetting curve in the future and not risk breaking the API again.

Idea 2: Keep the previous `Card.get_retrivability()` method, but explicity pass $w_{20}$ to it.

```python
w_20 = scheduler_parameters[20]
retrievability = card.get_retrievability(w_20, some_datetime)
```

This is similar to idea 1, but instead of passing all of the scheduler parameters, the developer only needs to pass the relevant parameter used in the calculation.

Idea 3: Remove the `Card.get_retrievability()` method in favor of a `Scheduler.get_card_retrievability(card: Card, current_datetime: datetime)`

```python
retrievability = scheduler.get_card_retrievability(some_card, some_datetime)
```

This last idea requires that the developer uses an existing `Scheduler` object to compute a given `Card` object's retrievability. I think this is probably the best way to go about it since you can now longer compute a card's retrievability on its own with FSRS 6. The con is that we would remove the old `Card.get_retrievability()` method.

While this PR currently implements Idea 1, I'm currently in favor of Idea 3. Let me know what you think!