### PR TITLE
Speed up optimizer unit tests with parallelization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
         run: |
           uv pip install ".[optimizer,dev]"
       - name: Test with pytest
-        run: pytest
+        run: pytest -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 Homepage = "https://github.com/open-spaced-repetition/py-fsrs"
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv"]
+dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv", "pytest-xdist"]
 optimizer = ["torch", "numpy", "pandas"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
I was getting a bit frustrated with how long the optimizer unit tests were taking to complete, so I thought I'd get the tests to run in parallel instead.

To do this, I added the `pytest-xdist` pytest plugin as a dev dependency and replaced running `pytest` with `pytest -n auto` in the `test.yml` workflow.

If we now compare the execution time for this [most recent run](https://github.com/open-spaced-repetition/py-fsrs/actions/runs/15200433462) (with parallelization) to the [run before](https://github.com/open-spaced-repetition/py-fsrs/actions/runs/15169860912) (with no parallelization), we see that we can save a bit over 2 minutes if we run pytest in parallel.

Let me know if there are any questions 👍