### PR TITLE
Use match structures

### DIFF
--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -418,13 +418,6 @@ class Scheduler:
             (review_datetime - card.last_review).days if card.last_review else None
         )
 
-        review_log = ReviewLog(
-            card_id=card.card_id,
-            rating=rating,
-            review_datetime=review_datetime,
-            review_duration=review_duration,
-        )
-
         match card.state:
             case State.Learning:
                 # update the card's stability and difficulty
@@ -641,6 +634,13 @@ class Scheduler:
 
         card.due = review_datetime + next_interval
         card.last_review = review_datetime
+
+        review_log = ReviewLog(
+            card_id=card.card_id,
+            rating=rating,
+            review_datetime=review_datetime,
+            review_duration=review_duration,
+        )
 
         return card, review_log
 


### PR DESCRIPTION
Since we're using python 3.10+, we can use [match structures](https://peps.python.org/pep-0636/).

Given this, I was thinking that it'd be more clean to replace certain `if-elif-else` structures with `match-case` structures. In particular, I thought that certain `if-elif-else` structures within the `Scheduler.review_card` method to do with `Rating` or `State` were good candidates to replace with `match`.

Let me know what you think!