### PR TITLE
Add check for code formatting in Ruff GH action

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,3 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
+
+      - name: Check code formatting
+        run: ruff format --check


### PR DESCRIPTION
Currently, [our ruff gh action](https://github.com/open-spaced-repetition/py-fsrs/blob/main/.github/workflows/ruff.yml) only checks for linting errors but not formatting errors.

Given that `ruff` is also great for formatting, I included a code formatting check that also uses `ruff`.

Additionally, I also upgraded the official ruff gh action to use the latest v3 now

Let me know if you have any questions 👍