### PR TITLE
Fix error with non-existing function

### DIFF
--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -563,8 +563,8 @@ class Scheduler:
                     card.stability = self._next_stability(
                         difficulty=card.difficulty,
                         stability=card.stability,
-                        retrievability=card.get_retrievability(
-                            scheduler_parameters=self.parameters,
+                        retrievability=self.get_card_retrievability(
+                            card,
                             current_datetime=review_datetime,
                         ),
                         rating=rating,


### PR DESCRIPTION
In Scheduler, when card.state == State.Relearning card.get_retrievability throw exception because card does not have a get_retrievability method.