### PR TITLE
Bump patch for release 6.0.0 -> 6.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "6.0.0"
+version = "6.0.1"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
A small bug was found in #112 and I'd like to release a patch so I bumped the patch number in the `pyproject.toml` to `6.0.1`.