### PR TITLE
Generate py-fsrs documention and host on Github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: website
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # allows us to also manually trigger workflow if we want
+
+# security: restrict permissions for CI jobs.
+permissions:
+  contents: read
+
+jobs:
+  # Build the documentation and upload the static HTML files as an artifact.
+  build:
+    # the job will run when publishing a non-prerelease release or a manual workflow run
+    if: github.event_name != 'release' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # ADJUST THIS: install all dependencies (including pdoc)
+      - run: pip install -e .
+      - run: pip install pdoc
+      # ADJUST THIS: build your documentation into docs/.
+      # We use a custom build script for pdoc itself, ideally you just run `pdoc -o docs/ ...` here.
+      - run: pdoc fsrs --logo "https://joshdavham.com/assets/images/osr_logo.svg" --favicon "https://joshdavham.com/assets/images/osr_logo.svg" -o docs/
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+  # Deploy the artifact to GitHub pages.
+  # This is a separate job so that only actions/deploy-pages has the necessary permissions.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # MacOS
 .DS_Store
+
+# Documentation
+docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 Homepage = "https://github.com/open-spaced-repetition/py-fsrs"
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv", "pytest-xdist"]
+dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv", "pytest-xdist", "pdoc"]
 optimizer = ["torch", "numpy", "pandas"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Similar to what `ts-fsrs` is doing with [TypeDoc](https://open-spaced-repetition.github.io/ts-fsrs/), I thought it'd be a good idea if py-fsrs also had a documentation page.

For this, I went with [pdoc](https://pdoc.dev/) (made by the same people behind [autofix.ci](https://autofix.ci/)).

Basically how it'd work is, whenever we publish a new (non pre-release) release of py-fsrs, this github action will automatically deploy a new documentation site to this repo's github pages. I also added the `workflow_dispatch` trigger in the action as well so we can manually release new documentation in between publishing releases if we want.

I also added `pdoc` to the optional `dev` dependencies. If you wanna test locally, just run 

```bash
pdoc fsrs --logo "https://joshdavham.com/assets/images/osr_logo.svg" --favicon "https://joshdavham.com/assets/images/osr_logo.svg" -o docs/
``` 

(I hosted the osr logo on my personal site temporarily since the logo shared from the osr gh org wasn't working right)

Let me know if you have any questions 👍