### PR TITLE
Add __eq__ methods

### DIFF
--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -204,6 +204,9 @@ class Card:
             f"last_review={self.last_review})"
         )
 
+    def __eq__(self, other_card: Card) -> bool:
+        return isinstance(other_card, Card) and self.__dict__ == other_card.__dict__
+
     def to_dict(self) -> dict[str, int | float | str | None]:
         """
         Returns a JSON-serializable dictionary representation of the Card object.
@@ -300,6 +303,12 @@ class ReviewLog:
             f"rating={self.rating}, "
             f"review_datetime={self.review_datetime}, "
             f"review_duration={self.review_duration})"
+        )
+
+    def __eq__(self, other_review_log: ReviewLog) -> bool:
+        return (
+            isinstance(other_review_log, ReviewLog)
+            and self.__dict__ == other_review_log.__dict__
         )
 
     def to_dict(
@@ -427,6 +436,12 @@ class Scheduler:
             f"relearning_steps={self.relearning_steps}, "
             f"maximum_interval={self.maximum_interval}, "
             f"enable_fuzzing={self.enable_fuzzing})"
+        )
+
+    def __eq__(self, other_scheduler: Scheduler) -> bool:
+        return (
+            isinstance(other_scheduler, Scheduler)
+            and self.__dict__ == other_scheduler.__dict__
         )
 
     def get_card_retrievability(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 import json
 import pytest
 import random
+from copy import deepcopy
 
 
 class TestPyFSRS:
@@ -791,3 +792,31 @@ class TestPyFSRS:
         too_many_parameters = DEFAULT_PARAMETERS + (1, 2, 3)
         with pytest.raises(ValueError):
             Scheduler(parameters=too_many_parameters)
+
+    def test_class___eq___methods(self):
+        scheduler1 = Scheduler()
+        scheduler2 = Scheduler(desired_retention=0.91)
+        scheduler1_copy = deepcopy(scheduler1)
+
+        assert scheduler1 != scheduler2
+        assert scheduler1 == scheduler1_copy
+
+        card_orig = Card()
+        card_orig_copy = deepcopy(card_orig)
+
+        assert card_orig == card_orig_copy
+
+        card_review_1, review_log_review_1 = scheduler1.review_card(
+            card=card_orig, rating=Rating.Good
+        )
+
+        review_log_review_1_copy = deepcopy(review_log_review_1)
+
+        assert card_orig != card_review_1
+        assert review_log_review_1 == review_log_review_1_copy
+
+        _, review_log_review_2 = scheduler1.review_card(
+            card=card_review_1, rating=Rating.Good
+        )
+
+        assert review_log_review_1 != review_log_review_2


### PR DESCRIPTION
By default, python only considers two objects of the same class to be equal if they are literally the same object.

For example, we currently get this behavior:

```python
from fsrs import Card
from copy import deepcopy

card1 = Card()
card2 = deepcopy(card1)

card1 == card2
# > False
```

In order to be able to compare two objects for equality when they are equal in attributes (but not necessarily the same object), we need to override the class's `__eq__` method.

I went and added `__eq__` methods to the `Card`, `ReviewLog` and `Scheduler` classes and now we can compare objects of theses classes for equality:

```python
from fsrs import Card
from copy import deepcopy

card1 = Card()
card2 = deepcopy(card1)

card1 == card2
# > True
```

I also added a new unit test to test these methods.

Let me know if you have any questions 👍