### PR TITLE
Add full code coverage for basic, non-optimizer code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           uv pip install ".[optimizer,dev]"
 
       - name: Test with pytest
-        run: pytest --cov=fsrs --cov-branch --cov-report=xml -n auto
+        run: pytest --cov=fsrs --cov-report=xml -n auto
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5

--- a/fsrs/fsrs.py
+++ b/fsrs/fsrs.py
@@ -598,10 +598,6 @@ class Scheduler:
                     card.stability = self._short_term_stability(
                         stability=card.stability, rating=rating
                     )
-                    card.difficulty = self._next_difficulty(
-                        difficulty=card.difficulty, rating=rating
-                    )
-
                 else:
                     card.stability = self._next_stability(
                         difficulty=card.difficulty,
@@ -612,9 +608,10 @@ class Scheduler:
                         ),
                         rating=rating,
                     )
-                    card.difficulty = self._next_difficulty(
-                        difficulty=card.difficulty, rating=rating
-                    )
+
+                card.difficulty = self._next_difficulty(
+                    difficulty=card.difficulty, rating=rating
+                )
 
                 # calculate the card's next interval
                 match rating:


### PR DESCRIPTION
Previously, the code for the basic `fsrs.py` module wasn't fully covered so I went and added some more unit tests to bring it to full 100% code coverage.

However, with that being said, this package's code is still not yet fully covered since not all of the optimizer code is currently covered. This will be for a future PR.

Additionally, I modified the `test.yml` github action to compute *line* coverage rather than *branch* coverage for now. Line coverage is the default type of coverage and it is also the recommended type of coverage to track when starting out with code coverage according to [this article](https://about.codecov.io/blog/line-or-branch-coverage-which-type-is-right-for-you/). We could move back to branch coverage perhaps once we bring this package to full coverage with the optimizer, I think.

(and I also removed a small bit of code duplication that I spotted as well)

Let me know if you have any questions!