### PR TITLE
Make codebase more modular

### DIFF
--- a/fsrs/__init__.py
+++ b/fsrs/__init__.py
@@ -5,25 +5,10 @@ py-fsrs
 Py-FSRS is the official Python implementation of the FSRS scheduler algorithm, which can be used to develop spaced repetition systems.
 """
 
-from .fsrs import (
-    Scheduler,
-    Card,
-    Rating,
-    ReviewLog,
-    State,
-    DEFAULT_PARAMETERS,
-    STABILITY_MIN,
-)
+from fsrs.scheduler import Scheduler
+from fsrs.card import Card, State
+from fsrs.review_log import ReviewLog, Rating
 
-from .optimizer import Optimizer
+from fsrs.optimizer import Optimizer
 
-__all__ = [
-    "Scheduler",
-    "Card",
-    "Rating",
-    "ReviewLog",
-    "State",
-    "Optimizer",
-    "DEFAULT_PARAMETERS",
-    "STABILITY_MIN",
-]
+__all__ = ["Scheduler", "Card", "Rating", "ReviewLog", "State", "Optimizer"]

--- a/fsrs/card.py
+++ b/fsrs/card.py
@@ -1,0 +1,145 @@
+"""
+fsrs.card
+---------
+
+This module defines the Card and State classes.
+
+Classes:
+    Card: Represents a flashcard in the FSRS system.
+    State: Enum representing the learning state of a Card object.
+"""
+
+from __future__ import annotations
+from enum import IntEnum
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import time
+
+
+class State(IntEnum):
+    """
+    Enum representing the learning state of a Card object.
+    """
+
+    Learning = 1
+    Review = 2
+    Relearning = 3
+
+
+@dataclass(init=False)
+class Card:
+    """
+    Represents a flashcard in the FSRS system.
+
+    Attributes:
+        card_id: The id of the card. Defaults to the epoch milliseconds of when the card was created.
+        state: The card's current learning state.
+        step: The card's current learning or relearning step or None if the card is in the Review state.
+        stability: Core mathematical parameter used for future scheduling.
+        difficulty: Core mathematical parameter used for future scheduling.
+        due: The date and time when the card is due next.
+        last_review: The date and time of the card's last review.
+    """
+
+    card_id: int
+    state: State
+    step: int | None
+    stability: float | None
+    difficulty: float | None
+    due: datetime
+    last_review: datetime | None
+
+    def __init__(
+        self,
+        card_id: int | None = None,
+        state: State = State.Learning,
+        step: int | None = None,
+        stability: float | None = None,
+        difficulty: float | None = None,
+        due: datetime | None = None,
+        last_review: datetime | None = None,
+    ) -> None:
+        if card_id is None:
+            # epoch milliseconds of when the card was created
+            card_id = int(datetime.now(timezone.utc).timestamp() * 1000)
+            # wait 1ms to prevent potential card_id collision on next Card creation
+            time.sleep(0.001)
+        self.card_id = card_id
+
+        self.state = state
+
+        if self.state == State.Learning and step is None:
+            step = 0
+        self.step = step
+
+        self.stability = stability
+        self.difficulty = difficulty
+
+        if due is None:
+            due = datetime.now(timezone.utc)
+        self.due = due
+
+        self.last_review = last_review
+
+    def to_dict(self) -> dict[str, int | float | str | None]:
+        """
+        Returns a JSON-serializable dictionary representation of the Card object.
+
+        This method is specifically useful for storing Card objects in a database.
+
+        Returns:
+            A dictionary representation of the Card object.
+        """
+
+        return_dict = {
+            "card_id": self.card_id,
+            "state": self.state.value,
+            "step": self.step,
+            "stability": self.stability,
+            "difficulty": self.difficulty,
+            "due": self.due.isoformat(),
+            "last_review": self.last_review.isoformat() if self.last_review else None,
+        }
+
+        return return_dict
+
+    @staticmethod
+    def from_dict(source_dict: dict[str, int | float | str | None]) -> Card:
+        """
+        Creates a Card object from an existing dictionary.
+
+        Args:
+            source_dict: A dictionary representing an existing Card object.
+
+        Returns:
+            A Card object created from the provided dictionary.
+        """
+
+        card_id = int(source_dict["card_id"])
+        state = State(int(source_dict["state"]))
+        step = source_dict["step"]
+        stability = (
+            float(source_dict["stability"]) if source_dict["stability"] else None
+        )
+        difficulty = (
+            float(source_dict["difficulty"]) if source_dict["difficulty"] else None
+        )
+        due = datetime.fromisoformat(source_dict["due"])
+        last_review = (
+            datetime.fromisoformat(source_dict["last_review"])
+            if source_dict["last_review"]
+            else None
+        )
+
+        return Card(
+            card_id=card_id,
+            state=state,
+            step=step,
+            stability=stability,
+            difficulty=difficulty,
+            due=due,
+            last_review=last_review,
+        )
+
+
+__all__ = ["Card", "State"]

--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -5,15 +5,15 @@ fsrs.optimizer
 This module defines the optional Optimizer class.
 """
 
-from .fsrs import (
-    Card,
-    ReviewLog,
+from fsrs.card import Card
+from fsrs.review_log import ReviewLog, Rating
+from fsrs.scheduler import (
     Scheduler,
-    Rating,
     DEFAULT_PARAMETERS,
     LOWER_BOUNDS_PARAMETERS,
     UPPER_BOUNDS_PARAMETERS,
 )
+
 import math
 from datetime import datetime, timezone
 from copy import deepcopy
@@ -664,4 +664,9 @@ except ImportError:
 
     class Optimizer:
         def __init__(self, *args, **kwargs) -> None:
-            raise ImportError("The Optimizer class requires torch be installed.")
+            raise ImportError(
+                'Optimizer is not installed.\nInstall it with: pip install "fsrs[optimizer]"'
+            )
+
+
+__all__ = ["Optimizer"]

--- a/fsrs/review_log.py
+++ b/fsrs/review_log.py
@@ -1,0 +1,94 @@
+"""
+fsrs.review_log
+---------
+
+This module defines the ReviewLog and Rating classes.
+
+Classes:
+    ReviewLog: Represents the log entry of a Card that has been reviewed.
+    Rating: Enum representing the four possible ratings when reviewing a card.
+"""
+
+from __future__ import annotations
+from enum import IntEnum
+from dataclasses import dataclass
+from datetime import datetime
+
+
+class Rating(IntEnum):
+    """
+    Enum representing the four possible ratings when reviewing a card.
+    """
+
+    Again = 1
+    Hard = 2
+    Good = 3
+    Easy = 4
+
+
+@dataclass
+class ReviewLog:
+    """
+    Represents the log entry of a Card object that has been reviewed.
+
+    Attributes:
+        card_id: The id of the card being reviewed.
+        rating: The rating given to the card during the review.
+        review_datetime: The date and time of the review.
+        review_duration: The number of miliseconds it took to review the card or None if unspecified.
+    """
+
+    card_id: int
+    rating: Rating
+    review_datetime: datetime
+    review_duration: int | None
+
+    def to_dict(
+        self,
+    ) -> dict[str, dict | int | str | None]:
+        """
+        Returns a JSON-serializable dictionary representation of the ReviewLog object.
+
+        This method is specifically useful for storing ReviewLog objects in a database.
+
+        Returns:
+            A dictionary representation of the ReviewLog object.
+        """
+
+        return_dict = {
+            "card_id": self.card_id,
+            "rating": self.rating.value,
+            "review_datetime": self.review_datetime.isoformat(),
+            "review_duration": self.review_duration,
+        }
+
+        return return_dict
+
+    @staticmethod
+    def from_dict(
+        source_dict: dict[str, dict | int | str | None],
+    ) -> ReviewLog:
+        """
+        Creates a ReviewLog object from an existing dictionary.
+
+        Args:
+            source_dict: A dictionary representing an existing ReviewLog object.
+
+        Returns:
+            A ReviewLog object created from the provided dictionary.
+        """
+
+        card_id = source_dict["card_id"]
+        rating = Rating(int(source_dict["rating"]))
+        review_datetime = datetime.fromisoformat(source_dict["review_datetime"])
+        review_duration = source_dict["review_duration"]
+
+        return ReviewLog(
+            card_id=card_id,
+            rating=rating,
+            review_datetime=review_datetime,
+            review_duration=review_duration,
+        )
+
+
+__all__ = ["ReviewLog", "Rating"]

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -1,14 +1,10 @@
 """
-fsrs.fsrs
+fsrs.scheduler
 ---------
 
-This module defines each of the classes used in the fsrs package.
+This module defines the Scheduler class as well as the various constants used in its calculations.
 
 Classes:
-    State: Enum representing the learning state of a Card object.
-    Rating: Enum representing the four possible ratings when reviewing a card.
-    Card: Represents a flashcard in the FSRS system.
-    ReviewLog: Represents the log entry of a Card that has been reviewed.
     Scheduler: The FSRS spaced-repetition scheduler.
 """
 
@@ -17,10 +13,10 @@ from collections.abc import Sequence
 import math
 from datetime import datetime, timezone, timedelta
 from copy import copy
-from enum import IntEnum
 from random import random
-import time
 from dataclasses import dataclass
+from fsrs.card import Card, State
+from fsrs.review_log import ReviewLog, Rating
 
 DEFAULT_PARAMETERS = (
     0.2172,
@@ -116,208 +112,6 @@ FUZZ_RANGES = [
         "factor": 0.05,
     },
 ]
-
-
-class State(IntEnum):
-    """
-    Enum representing the learning state of a Card object.
-    """
-
-    Learning = 1
-    Review = 2
-    Relearning = 3
-
-
-class Rating(IntEnum):
-    """
-    Enum representing the four possible ratings when reviewing a card.
-    """
-
-    Again = 1
-    Hard = 2
-    Good = 3
-    Easy = 4
-
-
-@dataclass(init=False)
-class Card:
-    """
-    Represents a flashcard in the FSRS system.
-
-    Attributes:
-        card_id: The id of the card. Defaults to the epoch milliseconds of when the card was created.
-        state: The card's current learning state.
-        step: The card's current learning or relearning step or None if the card is in the Review state.
-        stability: Core mathematical parameter used for future scheduling.
-        difficulty: Core mathematical parameter used for future scheduling.
-        due: The date and time when the card is due next.
-        last_review: The date and time of the card's last review.
-    """
-
-    card_id: int
-    state: State
-    step: int | None
-    stability: float | None
-    difficulty: float | None
-    due: datetime
-    last_review: datetime | None
-
-    def __init__(
-        self,
-        card_id: int | None = None,
-        state: State = State.Learning,
-        step: int | None = None,
-        stability: float | None = None,
-        difficulty: float | None = None,
-        due: datetime | None = None,
-        last_review: datetime | None = None,
-    ) -> None:
-        if card_id is None:
-            # epoch milliseconds of when the card was created
-            card_id = int(datetime.now(timezone.utc).timestamp() * 1000)
-            # wait 1ms to prevent potential card_id collision on next Card creation
-            time.sleep(0.001)
-        self.card_id = card_id
-
-        self.state = state
-
-        if self.state == State.Learning and step is None:
-            step = 0
-        self.step = step
-
-        self.stability = stability
-        self.difficulty = difficulty
-
-        if due is None:
-            due = datetime.now(timezone.utc)
-        self.due = due
-
-        self.last_review = last_review
-
-    def to_dict(self) -> dict[str, int | float | str | None]:
-        """
-        Returns a JSON-serializable dictionary representation of the Card object.
-
-        This method is specifically useful for storing Card objects in a database.
-
-        Returns:
-            A dictionary representation of the Card object.
-        """
-
-        return_dict = {
-            "card_id": self.card_id,
-            "state": self.state.value,
-            "step": self.step,
-            "stability": self.stability,
-            "difficulty": self.difficulty,
-            "due": self.due.isoformat(),
-            "last_review": self.last_review.isoformat() if self.last_review else None,
-        }
-
-        return return_dict
-
-    @staticmethod
-    def from_dict(source_dict: dict[str, int | float | str | None]) -> Card:
-        """
-        Creates a Card object from an existing dictionary.
-
-        Args:
-            source_dict: A dictionary representing an existing Card object.
-
-        Returns:
-            A Card object created from the provided dictionary.
-        """
-
-        card_id = int(source_dict["card_id"])
-        state = State(int(source_dict["state"]))
-        step = source_dict["step"]
-        stability = (
-            float(source_dict["stability"]) if source_dict["stability"] else None
-        )
-        difficulty = (
-            float(source_dict["difficulty"]) if source_dict["difficulty"] else None
-        )
-        due = datetime.fromisoformat(source_dict["due"])
-        last_review = (
-            datetime.fromisoformat(source_dict["last_review"])
-            if source_dict["last_review"]
-            else None
-        )
-
-        return Card(
-            card_id=card_id,
-            state=state,
-            step=step,
-            stability=stability,
-            difficulty=difficulty,
-            due=due,
-            last_review=last_review,
-        )
-
-
-@dataclass
-class ReviewLog:
-    """
-    Represents the log entry of a Card object that has been reviewed.
-
-    Attributes:
-        card_id: The id of the card being reviewed.
-        rating: The rating given to the card during the review.
-        review_datetime: The date and time of the review.
-        review_duration: The number of miliseconds it took to review the card or None if unspecified.
-    """
-
-    card_id: int
-    rating: Rating
-    review_datetime: datetime
-    review_duration: int | None
-
-    def to_dict(
-        self,
-    ) -> dict[str, dict | int | str | None]:
-        """
-        Returns a JSON-serializable dictionary representation of the ReviewLog object.
-
-        This method is specifically useful for storing ReviewLog objects in a database.
-
-        Returns:
-            A dictionary representation of the ReviewLog object.
-        """
-
-        return_dict = {
-            "card_id": self.card_id,
-            "rating": self.rating.value,
-            "review_datetime": self.review_datetime.isoformat(),
-            "review_duration": self.review_duration,
-        }
-
-        return return_dict
-
-    @staticmethod
-    def from_dict(
-        source_dict: dict[str, dict | int | str | None],
-    ) -> ReviewLog:
-        """
-        Creates a ReviewLog object from an existing dictionary.
-
-        Args:
-            source_dict: A dictionary representing an existing ReviewLog object.
-
-        Returns:
-            A ReviewLog object created from the provided dictionary.
-        """
-
-        card_id = source_dict["card_id"]
-        rating = Rating(int(source_dict["rating"]))
-        review_datetime = datetime.fromisoformat(source_dict["review_datetime"])
-        review_duration = source_dict["review_duration"]
-
-        return ReviewLog(
-            card_id=card_id,
-            rating=rating,
-            review_datetime=review_datetime,
-            review_duration=review_duration,
-        )
 
 
 @dataclass(init=False)
@@ -930,3 +724,6 @@ class Scheduler:
         fuzzed_interval = timedelta(days=fuzzed_interval_days)
 
         return fuzzed_interval
+
+
+__all__ = ["Scheduler"]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,12 +1,7 @@
-from fsrs import (
-    Scheduler,
-    Card,
-    ReviewLog,
-    State,
-    Rating,
-    STABILITY_MIN,
-    DEFAULT_PARAMETERS,
-)
+from fsrs.scheduler import Scheduler, STABILITY_MIN, DEFAULT_PARAMETERS
+from fsrs.card import Card, State
+from fsrs.review_log import ReviewLog, Rating
+
 from datetime import datetime, timedelta, timezone
 import json
 import pytest

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,4 +1,8 @@
-from fsrs import ReviewLog, Optimizer, DEFAULT_PARAMETERS, Rating, Scheduler, Card
+from fsrs.optimizer import Optimizer
+from fsrs.review_log import ReviewLog, Rating
+from fsrs.scheduler import Scheduler, DEFAULT_PARAMETERS
+from fsrs.card import Card
+
 import pandas as pd
 from copy import deepcopy
 from random import shuffle


### PR DESCRIPTION
Up until now, all of the non-optimizer code has lived in the single, long `fsrs/fsrs.py` file. I was thinking that it'd be a good idea to break it up into a couple smaller files to make the codebase more modular.

To do this, I broke `fsrs.py` into `scheduler.py`, `card.py` and `review_log.py` as `Scheduler`, `Card` and `ReviewLog` are the major classes aside from the optional `Optimizer` class.

I also made some minor adjustments along the way such as adding an `__all__` list to each module as well as removing `"DEFAULT_PARAMETERS"` and `"STABILITY_MIN"` from the `__all__` list in the `fsrs/__init__.py` file since it's not necessary to export. Technically, the latter could be considered a breaking change if developers were relying on code such as
```python
from fsrs import DEFAULT_PARAMETERS, STABILITY_MIN
# then do stuff with DEFAULT_PARAMETERS or STABILITY_MIN below
```
... but I highly doubt any developers are depending on these constants being exported so I'd argue we shouldn't do a major version bump for this.

Edit: and I also updated the optional `Optimizer` `ImportError` message to be a little more explicit. The previous message wasn't very descriptive and caused a bit of confusion in the past.

Let me know what you think!