### PR TITLE
Minor release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "6.0.1"
+version = "6.1.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
We recently added `__eq__` methods to most of the classes and added a new `verbose` option to the optimizer so I was thinking that it'd be a good time for a minor release. I went and bumped the version in the `pyproject.toml` from `6.0.1` -> `6.1.0`.