### PR TITLE
Enforce keyword arguments in internal methods

### DIFF
--- a/fsrs/optimizer.py
+++ b/fsrs/optimizer.py
@@ -106,7 +106,7 @@ try:
             # format the ReviewLog data for optimization
             self._revlogs_train = _format_revlogs()
 
-        def _compute_batch_loss(self, parameters: list[float]) -> float:
+        def _compute_batch_loss(self, *, parameters: list[float]) -> float:
             """
             Computes the current total loss for the entire batch of review logs.
             """
@@ -214,7 +214,7 @@ try:
                 return num_reviews
 
             def _update_parameters(
-                step_losses: list,
+                *, step_losses: list,
                 adam_optimizer: torch.optim.Adam,
                 params: torch.Tensor,
                 lr_scheduler: torch.optim.lr_scheduler.CosineAnnealingLR,
@@ -511,7 +511,7 @@ try:
 
         def _simulate_cost(
             self,
-            desired_retention: float,
+            *, desired_retention: float,
             parameters: tuple[float, ...] | list[float],
             num_cards_simulate: int,
             probs_and_costs_dict: dict[str, float],

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -96,8 +96,8 @@ class TestOptimizer:
         assert np.allclose(optimal_parameters, test_optimal_parameters)
 
         # the computed loss with the optimized parameters are less than that of the starting parameters
-        starting_loss = optimizer._compute_batch_loss(DEFAULT_PARAMETERS)
-        optimized_loss = optimizer._compute_batch_loss(optimal_parameters)
+        starting_loss = optimizer._compute_batch_loss(parameters=DEFAULT_PARAMETERS)
+        optimized_loss = optimizer._compute_batch_loss(parameters=optimal_parameters)
         assert optimized_loss < starting_loss
 
         # calling the same optimizer again will yield the same parameters


### PR DESCRIPTION
In the codebase, we have internal methods such as

```python
  def _next_stability(
      self, difficulty: float, stability: float, retrievability: float, rating: Rating
  ) -> float:
```

which take many different float arguments.

Currently, it's possible to make mistakes when calling these functions by passing the arguments in the wrong order.

For example,
```python
# this will produce the wrong outcome
card.stability = self._next_stability(retrievability, difficulty, stability, rating)
```

If we add `*` to the beginning of functions or after `self` for methods, we can enforce the use of keywords.

```python
  def _next_stability(
      self, *, difficulty: float, stability: float, retrievability: float, rating: Rating
  ) -> float:
# ...

# calling this will result in an error
# card.stability = self._next_stability(retrievability, difficulty, stability, rating)

# you must now specify keywords
card.stability = self._next_stability(retrievability=retrievability, difficulty=difficulty, stability=stability, rating=rating)
```
-

I went and added `*`'s to all internal functions and methods to prevent these silly bugs as well as enforce more clarity in function calls.

Lmk if you have any questions

-

Also, side note: if we were re-building this repo from scratch, I think it would've been a better idea to enforce keywords on all public functions/methods as well. This would not only help prevent errors, but it would also safeguard us from introducing breaking changes in the future if we decided to reorder the arguments in a function definition. I think next time we introduce breaking changes, enforcing keyword arguments in the public api should be a part of that change.