### PR TITLE
Add lazy loading for the Optimizer module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,9 @@ jobs:
           uv pip install ".[optimizer,dev]"
 
       - name: Test with pytest
-        run: pytest --cov=fsrs --cov-report=xml -n auto
+        run: |
+          pytest --cov=fsrs --cov-report= --cov-append tests/test_basic.py
+          pytest --cov=fsrs --cov-report=xml --cov-append tests/test_optimizer.py -n auto
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5

--- a/fsrs/__init__.py
+++ b/fsrs/__init__.py
@@ -11,7 +11,7 @@ from fsrs.review_log import ReviewLog, Rating
 
 
 # lazy load the Optimizer module due to heavy dependencies
-def __getattr__(name):
+def __getattr__(name: str) -> type:
     if name == "Optimizer":
         global Optimizer
         from fsrs.optimizer import Optimizer

--- a/fsrs/__init__.py
+++ b/fsrs/__init__.py
@@ -9,6 +9,14 @@ from fsrs.scheduler import Scheduler
 from fsrs.card import Card, State
 from fsrs.review_log import ReviewLog, Rating
 
-from fsrs.optimizer import Optimizer
+
+# lazy load the Optimizer module due to heavy dependencies
+def __getattr__(name):
+    if name == "Optimizer":
+        from fsrs.optimizer import Optimizer
+
+        return Optimizer
+    raise AttributeError
+
 
 __all__ = ["Scheduler", "Card", "Rating", "ReviewLog", "State", "Optimizer"]

--- a/fsrs/__init__.py
+++ b/fsrs/__init__.py
@@ -13,6 +13,7 @@ from fsrs.review_log import ReviewLog, Rating
 # lazy load the Optimizer module due to heavy dependencies
 def __getattr__(name):
     if name == "Optimizer":
+        global Optimizer
         from fsrs.optimizer import Optimizer
 
         return Optimizer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "6.1.0"
+version = "6.1.1"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,6 +7,7 @@ import json
 import pytest
 import random
 from copy import deepcopy
+import sys
 
 
 class TestPyFSRS:
@@ -1041,3 +1042,14 @@ class TestPyFSRS:
 
         assert card.state == State.Review
         assert card.step is None
+
+    def test_Optimizer_lazy_loading(self):
+        assert "fsrs.scheduler" in sys.modules
+        assert "fsrs.card" in sys.modules
+        assert "fsrs.review_log" in sys.modules
+
+        assert "fsrs.optimizer" not in sys.modules
+
+        from fsrs import Optimizer  # noqa: F401 (linter: unused import)
+
+        assert "fsrs.optimizer" in sys.modules

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1053,3 +1053,7 @@ class TestPyFSRS:
         from fsrs import Optimizer  # noqa: F401 (linter: unused import)
 
         assert "fsrs.optimizer" in sys.modules
+
+    def test_import_non_existent_module(self):
+        with pytest.raises(ImportError):
+            from fsrs import NotAModule  # noqa: F401 (linter: unused import)


### PR DESCRIPTION
Closes #126 

Currently, developers who have installed the optional `[optimizer]` dependency must load the `Optimizer` module (and all of its dependencies) when first importing the `fsrs` package. This creates extra overhead during startup time even when the `Optimizer` module isn't explicitly imported.

For example, a developer who has `fsrs` installed without the optional `[optimizer]` dependencies can execute

```python
from fsrs import Card # (doesn't load torch since optmizer dep not installed)
```

quickly as it will not also load the `Optimizer` dependencies such as `torch`, etc.

However, a developer who has `fsrs` installed with the optional `[optimizer]` dependencies will find that the same

```python
from fsrs import Card # (DOES load torch since optimizer dep installed)
```

takes much longer even though they never explicitly imported the `Optimizer`.

--

To remedy this, I've added some logic for lazy loading in the `fsrs/__init__.py` module which will make it so that the `Optimizer` module will only be loaded if it's explicitly imported: e.g.,

```python
from fsrs import Card # this will not load torch
from fsrs import Optimizer # this WILL load torch
```

I've also included a new unit test to test the lazy loading.