### PR TITLE
JSON serialization and deserialization support to the main data classes (Card, ReviewLog, and Scheduler) 

### DIFF
--- a/fsrs/card.py
+++ b/fsrs/card.py
@@ -10,6 +10,8 @@ Classes:
 """
 
 from __future__ import annotations
+
+import json
 from enum import IntEnum
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -140,6 +142,32 @@ class Card:
             due=due,
             last_review=last_review,
         )
+
+    def to_json(self) -> str:
+        """
+        Returns a JSON-serializable representation of the Card object.
+
+        This method is specifically useful for storing Card objects in a database.
+
+        Returns:
+            A JSON representation of the Card object.
+        """
+
+        return json.dumps(self.to_dict())
+
+    @staticmethod
+    def from_json(source_json: str) -> Card:
+        """
+        Creates a Card object from an existing JSON.
+
+        Args:
+            source_json: A JSON representing an existing Card object.
+
+        Returns:
+            A Card object created from the provided JSON.
+        """
+
+        return Card.from_dict(json.loads(source_json))
 
 
 __all__ = ["Card", "State"]

--- a/fsrs/review_log.py
+++ b/fsrs/review_log.py
@@ -10,6 +10,8 @@ Classes:
 """
 
 from __future__ import annotations
+
+import json
 from enum import IntEnum
 from dataclasses import dataclass
 from datetime import datetime
@@ -89,6 +91,32 @@ class ReviewLog:
             review_datetime=review_datetime,
             review_duration=review_duration,
         )
+
+    def to_json(self) -> str:
+        """
+        Returns a JSON-serializable representation of the ReviewLog object.
+
+        This method is specifically useful for storing ReviewLog objects in a database.
+
+        Returns:
+            A JSON representation of the ReviewLog object.
+        """
+
+        return json.dumps(self.to_dict())
+
+    @staticmethod
+    def from_json(source_json: str) -> ReviewLog:
+        """
+        Creates a ReviewLog object from an existing JSON.
+
+        Args:
+            source_json: A JSON representing an existing ReviewLog object.
+
+        Returns:
+            A ReviewLog object created from the provided JSON.
+        """
+
+        return ReviewLog.from_dict(json.loads(source_json))
 
 
 __all__ = ["ReviewLog", "Rating"]

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -549,13 +549,13 @@ class Scheduler:
     @staticmethod
     def from_json(source_json: str) -> Scheduler:
         """
-        Creates a Scheduler object from an existing dictionary.
+        Creates a Scheduler object from an existing JSON.
 
         Args:
-            source_dict: A dictionary representing an existing Scheduler object.
+            source_json: A JSON representing an existing Scheduler object.
 
         Returns:
-            A Scheduler object created from the provided dictionary.
+            A Scheduler object created from the provided JSON.
         """
 
         return Scheduler.from_dict(json.loads(source_json))

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -9,6 +9,8 @@ Classes:
 """
 
 from __future__ import annotations
+
+import json
 from collections.abc import Sequence
 import math
 from datetime import datetime, timezone, timedelta
@@ -531,6 +533,32 @@ class Scheduler:
             maximum_interval=maximum_interval,
             enable_fuzzing=enable_fuzzing,
         )
+
+    def to_json(self) -> str:
+        """
+        Returns a JSON-serializable representation of the Scheduler object.
+
+        This method is specifically useful for storing Scheduler objects in a database.
+
+        Returns:
+            A JSON representation of the Scheduler object.
+        """
+
+        return json.dumps(self.to_dict())
+
+    @staticmethod
+    def from_json(source_json: str) -> Scheduler:
+        """
+        Creates a Scheduler object from an existing dictionary.
+
+        Args:
+            source_dict: A dictionary representing an existing Scheduler object.
+
+        Returns:
+            A Scheduler object created from the provided dictionary.
+        """
+
+        return Scheduler.from_dict(json.loads(source_json))
 
     def _clamp_difficulty(self, *, difficulty: float) -> float:
         if isinstance(difficulty, (float, int)):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -164,6 +164,7 @@ class TestPyFSRS:
 
         # card object's to_dict() method makes it JSON serializable
         assert type(json.dumps(card.to_dict())) is str
+        assert type(card.to_json()) is str
 
         # we can reconstruct a copy of the card object equivalent to the original
         card_dict = card.to_dict()
@@ -171,6 +172,12 @@ class TestPyFSRS:
 
         assert vars(card) == vars(copied_card)
         assert card.to_dict() == copied_card.to_dict()
+
+        card_json = card.to_json()
+        copied_card = Card.from_json(card_json)
+
+        assert vars(card) == vars(copied_card)
+        assert card.to_json() == copied_card.to_json()
 
         # (x2) perform the above tests once more with a repeated card
         reviewed_card, _ = scheduler.review_card(
@@ -181,6 +188,7 @@ class TestPyFSRS:
             json.dumps(reviewed_card.__dict__)
 
         assert type(json.dumps(reviewed_card.to_dict())) is str
+        assert type(reviewed_card.to_json()) is str
 
         reviewed_card_dict = reviewed_card.to_dict()
         copied_reviewed_card = Card.from_dict(reviewed_card_dict)
@@ -191,6 +199,16 @@ class TestPyFSRS:
         # original card and repeated card are different
         assert vars(card) != vars(reviewed_card)
         assert card.to_dict() != reviewed_card.to_dict()
+
+        reviewed_card_json = reviewed_card.to_json()
+        copied_reviewed_card = Card.from_json(reviewed_card_json)
+
+        assert vars(reviewed_card) == vars(copied_reviewed_card)
+        assert reviewed_card.to_json() == copied_reviewed_card.to_json()
+
+        # original card and repeated card are different
+        assert vars(card) != vars(reviewed_card)
+        assert card.to_json() != reviewed_card.to_json()
 
     def test_ReviewLog_serialize(self):
         scheduler = Scheduler()
@@ -206,11 +224,16 @@ class TestPyFSRS:
 
         # review_log object's to_dict() method makes it JSON serializable
         assert type(json.dumps(review_log.to_dict())) is str
+        assert type(review_log.to_json()) is str
 
         # we can reconstruct a copy of the review_log object equivalent to the original
         review_log_dict = review_log.to_dict()
         copied_review_log = ReviewLog.from_dict(review_log_dict)
         assert review_log.to_dict() == copied_review_log.to_dict()
+
+        review_log_json = review_log.to_json()
+        copied_review_log = ReviewLog.from_json(review_log_json)
+        assert review_log.to_json() == copied_review_log.to_json()
 
         # (x2) perform the above tests once more with a review_log from a reviewed card
         rating = Rating.Good
@@ -230,6 +253,14 @@ class TestPyFSRS:
 
         # original review log and next review log are different
         assert review_log.to_dict() != next_review_log.to_dict()
+
+        next_review_log_json = next_review_log.to_json()
+        copied_next_review_log = ReviewLog.from_json(next_review_log_json)
+
+        assert next_review_log.to_json() == copied_next_review_log.to_json()
+
+        # original review log and next review log are different
+        assert review_log.to_json() != next_review_log.to_json()
 
     def test_custom_scheduler_args(self):
         scheduler = Scheduler(
@@ -348,12 +379,18 @@ class TestPyFSRS:
 
         # Scheduler objects are json-serializable through its .to_dict() method
         assert type(json.dumps(scheduler.to_dict())) is str
+        assert type(scheduler.to_json()) is str
 
         # scheduler can be serialized and de-serialized while remaining the same
         scheduler_dict = scheduler.to_dict()
         copied_scheduler = Scheduler.from_dict(scheduler_dict)
         assert vars(scheduler) == vars(copied_scheduler)
         assert scheduler.to_dict() == copied_scheduler.to_dict()
+
+        scheduler_json = scheduler.to_json()
+        copied_scheduler = Scheduler.from_json(scheduler_json)
+        assert vars(scheduler) == vars(copied_scheduler)
+        assert scheduler.to_json() == copied_scheduler.to_json()
 
     def test_good_learning_steps(self):
         scheduler = Scheduler()


### PR DESCRIPTION
This pull request adds JSON serialization and deserialization support to the main data classes (`Card`, `ReviewLog`, and `Scheduler`) in the codebase, making it easier to store and retrieve these objects from databases or transmit them over APIs. Corresponding tests are also added to ensure the correctness of these new methods.

**Serialization and Deserialization Enhancements**

* Added `to_json()` and `from_json()` methods to the `Card` class in `fsrs/card.py` to enable easy conversion to and from JSON strings.
* Added `to_json()` and `from_json()` methods to the `ReviewLog` class in `fsrs/review_log.py` for JSON-based serialization and deserialization.
* Added `to_json()` and `from_json()` methods to the `Scheduler` class in `fsrs/scheduler.py` for JSON serialization support.

**Testing Improvements**

* Extended tests in `tests/test_basic.py` for `Card`, `ReviewLog`, and `Scheduler` to verify that objects can be serialized to JSON and accurately reconstructed using the new methods. [[1]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R167) [[2]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R176-R181) [[3]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R191) [[4]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R203-R212) [[5]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R227-R237) [[6]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R257-R264) [[7]](diffhunk://#diff-29093b485f46bc37dda5e0854cfc54e289f24e206207afb81dff1c527cb001a7R382-R394)

**General Codebase Updates**

* Imported the `json` module in files where serialization methods were added (`fsrs/card.py`, `fsrs/review_log.py`, `fsrs/scheduler.py`). [[1]](diffhunk://#diff-14327ae78fa6b0169cef592ddc17de2a13999a6f31f963463ad7bf90c1f85ef6R13-R14) [[2]](diffhunk://#diff-9b89280a3c94d72a96cb694c519b8978e650c28c16d3926fcfa057903699ca25R13-R14) [[3]](diffhunk://#diff-ce1d23b8bc8e253e05359204e82aadb714de1a0ff5877da5447414eb24ecf772R12-R13)