### PR TITLE
Reintroduce mypy

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,19 @@
+name: Mypy typecheck
+
+on: [push, pull_request]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: pip install ".[optimizer,dev]"
+
+      - name: Run mypy
+        run: mypy
+      

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,21 @@ Now you're ready to make changes to files in the `fsrs` directory and see your c
 
 ### Pass the checks
 
-In order for your contribution to be accepted, your code must pass the linting checks and unit tests.
+In order for your contribution to be accepted, your code must pass the formatting, linting and type checks as well as unit tests.
+
+Format your code with:
+```bash
+ruff format
+```
 
 Lint your code with:
 ```bash
 ruff check --fix
+```
+
+Type check your code with:
+```bash
+mypy
 ```
 
 Run the tests with:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     <a href="https://github.com/open-spaced-repetition/py-fsrs/blob/main/LICENSE" style="text-decoration: none;"><img src="https://img.shields.io/badge/License-MIT-brightgreen.svg"></a>
     <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
     <a href="https://codecov.io/gh/open-spaced-repetition/py-fsrs" ><img src="https://codecov.io/gh/open-spaced-repetition/py-fsrs/graph/badge.svg?token=3G0FF6HZQD"/></a>
+    <a href="https://mypy-lang.org/"><img src="https://www.mypy-lang.org/static/mypy_badge.svg" /></a>
 </div>
 <br />
 

--- a/fsrs/__init__.py
+++ b/fsrs/__init__.py
@@ -8,6 +8,10 @@ Py-FSRS is the official Python implementation of the FSRS scheduler algorithm, w
 from fsrs.scheduler import Scheduler
 from fsrs.card import Card, State
 from fsrs.review_log import ReviewLog, Rating
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fsrs.optimizer import Optimizer
 
 
 # lazy load the Optimizer module due to heavy dependencies

--- a/fsrs/__init__.py
+++ b/fsrs/__init__.py
@@ -6,8 +6,10 @@ Py-FSRS is the official Python implementation of the FSRS scheduler algorithm, w
 """
 
 from fsrs.scheduler import Scheduler
-from fsrs.card import Card, State
-from fsrs.review_log import ReviewLog, Rating
+from fsrs.state import State
+from fsrs.card import Card
+from fsrs.rating import Rating
+from fsrs.review_log import ReviewLog
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/fsrs/card.py
+++ b/fsrs/card.py
@@ -14,6 +14,7 @@ from enum import IntEnum
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import time
+from typing import TypedDict
 
 
 class State(IntEnum):
@@ -24,6 +25,16 @@ class State(IntEnum):
     Learning = 1
     Review = 2
     Relearning = 3
+
+
+class CardDict(TypedDict):
+    card_id: int
+    state: int
+    step: int | None
+    stability: float | None
+    difficulty: float | None
+    due: str
+    last_review: str | None
 
 
 @dataclass(init=False)
@@ -81,7 +92,7 @@ class Card:
 
         self.last_review = last_review
 
-    def to_dict(self) -> dict[str, int | float | str | None]:
+    def to_dict(self) -> CardDict:
         """
         Returns a JSON-serializable dictionary representation of the Card object.
 
@@ -91,7 +102,7 @@ class Card:
             A dictionary representation of the Card object.
         """
 
-        return_dict = {
+        return {
             "card_id": self.card_id,
             "state": self.state.value,
             "step": self.step,
@@ -101,10 +112,8 @@ class Card:
             "last_review": self.last_review.isoformat() if self.last_review else None,
         }
 
-        return return_dict
-
     @staticmethod
-    def from_dict(source_dict: dict[str, int | float | str | None]) -> Card:
+    def from_dict(source_dict: CardDict) -> Card:
         """
         Creates a Card object from an existing dictionary.
 
@@ -115,30 +124,22 @@ class Card:
             A Card object created from the provided dictionary.
         """
 
-        card_id = int(source_dict["card_id"])
-        state = State(int(source_dict["state"]))
-        step = source_dict["step"]
-        stability = (
-            float(source_dict["stability"]) if source_dict["stability"] else None
-        )
-        difficulty = (
-            float(source_dict["difficulty"]) if source_dict["difficulty"] else None
-        )
-        due = datetime.fromisoformat(source_dict["due"])
-        last_review = (
-            datetime.fromisoformat(source_dict["last_review"])
-            if source_dict["last_review"]
-            else None
-        )
-
         return Card(
-            card_id=card_id,
-            state=state,
-            step=step,
-            stability=stability,
-            difficulty=difficulty,
-            due=due,
-            last_review=last_review,
+            card_id=int(source_dict["card_id"]),
+            state=State(int(source_dict["state"])),
+            step=source_dict["step"],
+            stability=(
+                float(source_dict["stability"]) if source_dict["stability"] else None
+            ),
+            difficulty=(
+                float(source_dict["difficulty"]) if source_dict["difficulty"] else None
+            ),
+            due=datetime.fromisoformat(source_dict["due"]),
+            last_review=(
+                datetime.fromisoformat(source_dict["last_review"])
+                if source_dict["last_review"]
+                else None
+            ),
         )
 
 

--- a/fsrs/card.py
+++ b/fsrs/card.py
@@ -18,6 +18,10 @@ from fsrs.state import State
 
 
 class CardDict(TypedDict):
+    """
+    JSON-serializable dictionary representation of a Card object.
+    """
+
     card_id: int
     state: int
     step: int | None

--- a/fsrs/card.py
+++ b/fsrs/card.py
@@ -10,21 +10,11 @@ Classes:
 """
 
 from __future__ import annotations
-from enum import IntEnum
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import time
 from typing import TypedDict
-
-
-class State(IntEnum):
-    """
-    Enum representing the learning state of a Card object.
-    """
-
-    Learning = 1
-    Review = 2
-    Relearning = 3
+from fsrs.state import State
 
 
 class CardDict(TypedDict):
@@ -143,4 +133,4 @@ class Card:
         )
 
 
-__all__ = ["Card", "State"]
+__all__ = ["Card"]

--- a/fsrs/rating.py
+++ b/fsrs/rating.py
@@ -1,0 +1,15 @@
+from enum import IntEnum
+
+
+class Rating(IntEnum):
+    """
+    Enum representing the four possible ratings when reviewing a card.
+    """
+
+    Again = 1
+    Hard = 2
+    Good = 3
+    Easy = 4
+
+
+__all__ = ["Rating"]

--- a/fsrs/review_log.py
+++ b/fsrs/review_log.py
@@ -10,21 +10,10 @@ Classes:
 """
 
 from __future__ import annotations
-from enum import IntEnum
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TypedDict
-
-
-class Rating(IntEnum):
-    """
-    Enum representing the four possible ratings when reviewing a card.
-    """
-
-    Again = 1
-    Hard = 2
-    Good = 3
-    Easy = 4
+from fsrs.rating import Rating
 
 
 class ReviewLogDict(TypedDict):
@@ -92,4 +81,4 @@ class ReviewLog:
         )
 
 
-__all__ = ["ReviewLog", "Rating"]
+__all__ = ["ReviewLog"]

--- a/fsrs/review_log.py
+++ b/fsrs/review_log.py
@@ -17,6 +17,10 @@ from fsrs.rating import Rating
 
 
 class ReviewLogDict(TypedDict):
+    """
+    JSON-serializable dictionary representation of a ReviewLog object.
+    """
+
     card_id: int
     rating: int
     review_datetime: str

--- a/fsrs/review_log.py
+++ b/fsrs/review_log.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from enum import IntEnum
 from dataclasses import dataclass
 from datetime import datetime
+from typing import TypedDict
 
 
 class Rating(IntEnum):
@@ -26,6 +27,13 @@ class Rating(IntEnum):
     Easy = 4
 
 
+class ReviewLogDict(TypedDict):
+    card_id: int
+    rating: int
+    review_datetime: str
+    review_duration: int | None
+
+
 @dataclass
 class ReviewLog:
     """
@@ -35,7 +43,7 @@ class ReviewLog:
         card_id: The id of the card being reviewed.
         rating: The rating given to the card during the review.
         review_datetime: The date and time of the review.
-        review_duration: The number of miliseconds it took to review the card or None if unspecified.
+        review_duration: The number of milliseconds it took to review the card or None if unspecified.
     """
 
     card_id: int
@@ -45,7 +53,7 @@ class ReviewLog:
 
     def to_dict(
         self,
-    ) -> dict[str, dict | int | str | None]:
+    ) -> ReviewLogDict:
         """
         Returns a JSON-serializable dictionary representation of the ReviewLog object.
 
@@ -55,18 +63,16 @@ class ReviewLog:
             A dictionary representation of the ReviewLog object.
         """
 
-        return_dict = {
+        return {
             "card_id": self.card_id,
-            "rating": self.rating.value,
+            "rating": int(self.rating),
             "review_datetime": self.review_datetime.isoformat(),
             "review_duration": self.review_duration,
         }
 
-        return return_dict
-
     @staticmethod
     def from_dict(
-        source_dict: dict[str, dict | int | str | None],
+        source_dict: ReviewLogDict,
     ) -> ReviewLog:
         """
         Creates a ReviewLog object from an existing dictionary.
@@ -78,16 +84,11 @@ class ReviewLog:
             A ReviewLog object created from the provided dictionary.
         """
 
-        card_id = source_dict["card_id"]
-        rating = Rating(int(source_dict["rating"]))
-        review_datetime = datetime.fromisoformat(source_dict["review_datetime"])
-        review_duration = source_dict["review_duration"]
-
         return ReviewLog(
-            card_id=card_id,
-            rating=rating,
-            review_datetime=review_datetime,
-            review_duration=review_duration,
+            card_id=source_dict["card_id"],
+            rating=Rating(int(source_dict["rating"])),
+            review_datetime=datetime.fromisoformat(source_dict["review_datetime"]),
+            review_duration=source_dict["review_duration"],
         )
 
 

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -260,8 +260,10 @@ class Scheduler:
 
         match card.state:
             case State.Learning:
+                assert card.step is not None
+
                 # update the card's stability and difficulty
-                if card.stability is None and card.difficulty is None:
+                if card.stability is None or card.difficulty is None:
                     card.stability = self._initial_stability(rating=rating)
                     card.difficulty = self._initial_difficulty(
                         rating=rating, clamp=True
@@ -346,6 +348,9 @@ class Scheduler:
                             next_interval = timedelta(days=next_interval_days)
 
             case State.Review:
+                assert card.stability is not None
+                assert card.difficulty is not None
+
                 # update the card's stability and difficulty
                 if days_since_last_review is not None and days_since_last_review < 1:
                     card.stability = self._short_term_stability(
@@ -389,6 +394,10 @@ class Scheduler:
                         next_interval = timedelta(days=next_interval_days)
 
             case State.Relearning:
+                assert card.stability is not None
+                assert card.difficulty is not None
+                assert card.step is not None
+
                 # update the card's stability and difficulty
                 if days_since_last_review is not None and days_since_last_review < 1:
                     card.stability = self._short_term_stability(

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -10,7 +10,7 @@ Classes:
 
 from __future__ import annotations
 from collections.abc import Sequence
-from numbers import Number
+from numbers import Real
 import math
 from datetime import datetime, timezone, timedelta
 from copy import copy
@@ -18,6 +18,7 @@ from random import random
 from dataclasses import dataclass
 from fsrs.card import Card, State
 from fsrs.review_log import ReviewLog, Rating
+from typing import TypedDict
 
 FSRS_DEFAULT_DECAY = 0.1542
 DEFAULT_PARAMETERS = (
@@ -114,6 +115,15 @@ FUZZ_RANGES = [
         "factor": 0.05,
     },
 ]
+
+
+class SchedulerDict(TypedDict):
+    parameters: list  # change to list[float]?
+    desired_retention: float
+    learning_steps: list  # change to list[int]
+    relearning_steps: list  # change to list[int]
+    maximum_interval: int
+    enable_fuzzing: bool
 
 
 @dataclass(init=False)
@@ -475,7 +485,7 @@ class Scheduler:
 
     def to_dict(
         self,
-    ) -> dict[str, list | float | int | bool]:
+    ) -> SchedulerDict:
         """
         Returns a JSON-serializable dictionary representation of the Scheduler object.
 
@@ -485,7 +495,7 @@ class Scheduler:
             A dictionary representation of the Scheduler object.
         """
 
-        return_dict = {
+        return {
             "parameters": list(self.parameters),
             "desired_retention": self.desired_retention,
             "learning_steps": [
@@ -500,10 +510,8 @@ class Scheduler:
             "enable_fuzzing": self.enable_fuzzing,
         }
 
-        return return_dict
-
     @staticmethod
-    def from_dict(source_dict: dict[str, list | float | int | bool]) -> Scheduler:
+    def from_dict(source_dict: SchedulerDict) -> Scheduler:
         """
         Creates a Scheduler object from an existing dictionary.
 
@@ -514,41 +522,34 @@ class Scheduler:
             A Scheduler object created from the provided dictionary.
         """
 
-        parameters = source_dict["parameters"]
-        desired_retention = source_dict["desired_retention"]
-        learning_steps = [
-            timedelta(seconds=learning_step)
-            for learning_step in source_dict["learning_steps"]
-        ]
-        relearning_steps = [
-            timedelta(seconds=relearning_step)
-            for relearning_step in source_dict["relearning_steps"]
-        ]
-        maximum_interval = source_dict["maximum_interval"]
-        enable_fuzzing = source_dict["enable_fuzzing"]
-
         return Scheduler(
-            parameters=parameters,
-            desired_retention=desired_retention,
-            learning_steps=learning_steps,
-            relearning_steps=relearning_steps,
-            maximum_interval=maximum_interval,
-            enable_fuzzing=enable_fuzzing,
+            parameters=source_dict["parameters"],
+            desired_retention=source_dict["desired_retention"],
+            learning_steps=[
+                timedelta(seconds=learning_step)
+                for learning_step in source_dict["learning_steps"]
+            ],
+            relearning_steps=[
+                timedelta(seconds=relearning_step)
+                for relearning_step in source_dict["relearning_steps"]
+            ],
+            maximum_interval=source_dict["maximum_interval"],
+            enable_fuzzing=source_dict["enable_fuzzing"],
         )
 
     def _clamp_difficulty(self, *, difficulty: float) -> float:
-        if isinstance(difficulty, Number):
+        if isinstance(difficulty, Real):
             difficulty = min(max(difficulty, MIN_DIFFICULTY), MAX_DIFFICULTY)
         else:  # type(difficulty) is torch.Tensor
-            difficulty = difficulty.clamp(min=MIN_DIFFICULTY, max=MAX_DIFFICULTY)
+            difficulty = difficulty.clamp(min=MIN_DIFFICULTY, max=MAX_DIFFICULTY)  # type: ignore[attr-defined]
 
         return difficulty
 
     def _clamp_stability(self, *, stability: float) -> float:
-        if isinstance(stability, Number):
+        if isinstance(stability, Real):
             stability = max(stability, STABILITY_MIN)
         else:  # type(stability) is torch.Tensor
-            stability = stability.clamp(min=STABILITY_MIN)
+            stability = stability.clamp(min=STABILITY_MIN)  # type: ignore[attr-defined]
 
         return stability
 
@@ -574,7 +575,7 @@ class Scheduler:
             (self.desired_retention ** (1 / self._DECAY)) - 1
         )
 
-        if not isinstance(next_interval, Number):  # type(next_interval) is torch.Tensor
+        if not isinstance(next_interval, Real):  # type(next_interval) is torch.Tensor
             next_interval = next_interval.detach().item()
 
         next_interval = round(next_interval)  # intervals are full days
@@ -593,7 +594,7 @@ class Scheduler:
         ) * (stability ** -self.parameters[19])
 
         if rating in (Rating.Good, Rating.Easy):
-            if isinstance(short_term_stability_increase, Number):
+            if isinstance(short_term_stability_increase, Real):
                 short_term_stability_increase = max(short_term_stability_increase, 1.0)
             else:  # type(short_term_stability_increase) is torch.Tensor
                 short_term_stability_increase = short_term_stability_increase.clamp(

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -120,6 +120,10 @@ FUZZ_RANGES = [
 
 
 class SchedulerDict(TypedDict):
+    """
+    JSON-serializable dictionary representation of a Scheduler object.
+    """
+
     parameters: list[float]
     desired_retention: float
     learning_steps: list[int]

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -118,10 +118,10 @@ FUZZ_RANGES = [
 
 
 class SchedulerDict(TypedDict):
-    parameters: list  # change to list[float]?
+    parameters: list[float]
     desired_retention: float
-    learning_steps: list  # change to list[int]
-    relearning_steps: list  # change to list[int]
+    learning_steps: list[int]
+    relearning_steps: list[int]
     maximum_interval: int
     enable_fuzzing: bool
 

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -16,8 +16,10 @@ from datetime import datetime, timezone, timedelta
 from copy import copy
 from random import random
 from dataclasses import dataclass
-from fsrs.card import Card, State
-from fsrs.review_log import ReviewLog, Rating
+from fsrs.state import State
+from fsrs.card import Card
+from fsrs.rating import Rating
+from fsrs.review_log import ReviewLog
 from typing import TypedDict
 
 FSRS_DEFAULT_DECAY = 0.1542

--- a/fsrs/state.py
+++ b/fsrs/state.py
@@ -1,0 +1,14 @@
+from enum import IntEnum
+
+
+class State(IntEnum):
+    """
+    Enum representing the learning state of a Card object.
+    """
+
+    Learning = 1
+    Review = 2
+    Relearning = 3
+
+
+__all__ = ["State"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,8 @@ optimizer = ["torch", "numpy", "pandas", "tqdm"]
 [tool.pytest.ini_options]
 pythonpath = "."
 filterwarnings = ["error"]
+
+[tool.mypy]
+files = ["fsrs/review_log.py"]
+follow_imports = "skip"
+exclude = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ pythonpath = "."
 filterwarnings = ["error"]
 
 [tool.mypy]
-files = ["fsrs/review_log.py"]
-follow_imports = "skip"
+files = ["fsrs"]
 exclude = "build"
+
+[[tool.mypy.overrides]]
+module = ["fsrs.optimizer"]
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 Homepage = "https://github.com/open-spaced-repetition/py-fsrs"
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv", "pytest-xdist", "pdoc", "tqdm", "pytest-cov"]
+dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv", "pytest-xdist", "pdoc", "tqdm", "pytest-cov", "mypy"]
 optimizer = ["torch", "numpy", "pandas", "tqdm"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ filterwarnings = ["error"]
 
 [tool.mypy]
 files = ["fsrs"]
-exclude = "build"
 
 [[tool.mypy.overrides]]
 module = ["fsrs.optimizer"]


### PR DESCRIPTION
Closes #99 

We originally removed `mypy` earlier this year in order to make adding the optimizer easier. Now that the optimizer has been implemented, I think we can add `mypy` back.

In this PR, I re-added `mypy` as a dev dependency and configured it to typecheck evertything in the `fsrs/` directory except for `fsrs/optimizer.py`. I also made some changes to the various modules in order to get them to pass `mypy`'s typechecks.

Additionally, I did the following:
1. I moved the `State` and `Rating` enums into their own modules `state.py` and `rating.py`, respectively to keep things more modular
2. I added a new `type-check.yml` github action to run `mypy` in CI
3. and I updated the `README.md` and `CONTRIBUTING.md`

Lmk if you have any questions 👍

--

(also, I still think it'll be a challenge to add type checking to the optimizer, but I've got some ideas that we could try out in the future)