### PR TITLE
Add method for rescheduling cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,20 @@ scheduler = Scheduler(optimal_parameters)
 optimal_retention = optimizer.compute_optimal_retention(optimal_parameters)
 
 # initialize a new scheduler with both optimized parameters and retention
-scheduler = Scheduler(optimal_parameters, optimal_retention)
+optimal_scheduler = Scheduler(optimal_parameters, optimal_retention)
 ```
 
-Note: The computed optimal parameters and retention may be slightly different than the numbers computed by Anki for the same set of review logs. This is because the two implementations are slightly different and updated at different times. If you're interested in the official Rust-based Anki implementation, please see [here](https://github.com/open-spaced-repetition/fsrs-rs).
+> [!NOTE]
+> Note: The computed optimal parameters and retention may be slightly different than the numbers computed by Anki for the same set of review logs. This is because the two implementations are slightly different and updated at different times. If you're interested in the official Rust-based Anki implementation, please see [here](https://github.com/open-spaced-repetition/fsrs-rs).
+
+### Reschedule cards after optimization
+
+After creating a new scheduler with optimized parameters, you may want to reschedule/update each of your previous cards with this new scheduler.
+
+```python
+# repeat the following for each of your cards
+rescheduled_card = optimal_scheduler.reschedule_card(card, review_logs_for_that_card)
+```
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ optimal_scheduler = Scheduler(optimal_parameters, optimal_retention)
 ```
 
 > [!NOTE]
-> Note: The computed optimal parameters and retention may be slightly different than the numbers computed by Anki for the same set of review logs. This is because the two implementations are slightly different and updated at different times. If you're interested in the official Rust-based Anki implementation, please see [here](https://github.com/open-spaced-repetition/fsrs-rs).
+> The computed optimal parameters and retention may be slightly different than the numbers computed by Anki for the same set of review logs. This is because the two implementations are slightly different and updated at different times. If you're interested in the official Rust-based Anki implementation, please see [here](https://github.com/open-spaced-repetition/fsrs-rs).
 
 ### Reschedule cards after optimization
 

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -498,6 +498,45 @@ class Scheduler:
 
         return card, review_log
 
+    def reschedule_card(self, card: Card, review_logs: list[ReviewLog]) -> Card:
+        """
+        Reschedules/updates the given card with the current scheduler provided that card's review logs.
+
+        If the current card was previously scheduled with a different scheduler, you may want to reschedule/update
+        it as if it had always been scheduled with this current scheduler. For example, you may want to reschedule
+        each of your cards with a new scheduler after computing the optimal parameters with the Optimizer.
+
+        Args:
+            card: The card to be rescheduled/updated.
+            review_logs: A list of that card's review logs (order doesn't matter).
+
+        Returns:
+            A new card that has rescheduled/updated with this current scheduler.
+
+        Raises:
+            ValueError: If any of the review logs are for a card other than the one specified, this will raise an error.
+
+        """
+
+        for review_log in review_logs:
+            if review_log.card_id != card.card_id:
+                raise ValueError(
+                    f"ReviewLog card_id {review_log.card_id} does not match Card card_id {card.card_id}"
+                )
+
+        review_logs = sorted(review_logs, key=lambda log: log.review_datetime)
+
+        rescheduled_card = Card(card_id=card.card_id, due=card.due)
+
+        for review_log in review_logs:
+            rescheduled_card, _ = self.review_card(
+                card=rescheduled_card,
+                rating=review_log.rating,
+                review_datetime=review_log.review_datetime,
+            )
+
+        return rescheduled_card
+
     def to_dict(
         self,
     ) -> SchedulerDict:

--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -511,7 +511,7 @@ class Scheduler:
             review_logs: A list of that card's review logs (order doesn't matter).
 
         Returns:
-            A new card that has rescheduled/updated with this current scheduler.
+            A new card that has been rescheduled/updated with this current scheduler.
 
         Raises:
             ValueError: If any of the review logs are for a card other than the one specified, this will raise an error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "6.1.1"
+version = "6.2.0"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
I added a new method `Scheduler.reschedule_card(card: Card, review_logs: list[ReviewLog]) -> Card` which takes a given card and its review logs and reruns it through its review history with the current scheduler.

This method is meant to be used when a developer switches to a new scheduler and would like to update their card's state as if it had always been scheduled by the new scheduler, rather than the old scheduler. This is especially useful for updating cards after the optimizer.

I also added some tests, updated the README and bumped the version from `6.1.1` to `6.2.0`.

Let me know if you have any questions 👍