### PR TITLE
Replace mypy with ty

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,4 +1,4 @@
-name: Mypy typecheck
+name: ty typecheck
 
 on: [push, pull_request]
 
@@ -14,6 +14,6 @@ jobs:
       - name: Install dependencies
         run: pip install ".[optimizer,dev]"
 
-      - name: Run mypy
-        run: mypy
+      - name: Run ty
+        run: ty check
       

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,12 +38,18 @@ ruff check --fix
 
 Type check your code with:
 ```bash
-mypy
+ty check
 ```
 
-Run the tests with:
+Run basic tests with:
 ```bash
-pytest
+pytest tests/test_basic.py
+```
+
+Run optimizer tests with:
+```bash
+# -n auto is for running multiple unit tests in parallel
+pytest tests/test_optimizer.py -n auto
 ```
 
 Additionally, you are strongly encouraged to contribute your own tests to [tests/](tests/) to help make Py-FSRS more reliable.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     <a href="https://github.com/open-spaced-repetition/py-fsrs/blob/main/LICENSE" style="text-decoration: none;"><img src="https://img.shields.io/badge/License-MIT-brightgreen.svg"></a>
     <a href="https://github.com/open-spaced-repetition/py-fsrs/actions/workflows/test.yml"><img src="https://github.com/open-spaced-repetition/py-fsrs/actions/workflows/test.yml/badge.svg" /></a>
     <a href="https://codecov.io/gh/open-spaced-repetition/py-fsrs" ><img src="https://codecov.io/gh/open-spaced-repetition/py-fsrs/graph/badge.svg?token=3G0FF6HZQD"/></a>
-    <a href="https://mypy-lang.org/"><img src="https://www.mypy-lang.org/static/mypy_badge.svg" /></a>
+    <a href="https://github.com/astral-sh/ty"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json" /></a>
     <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"></a>
     <a href="https://interactive-forgetting-curve.streamlit.app/"><img src="https://img.shields.io/badge/-Streamlit-FF4B4B?style=flat&logo=streamlit&logoColor=white" ></a>
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,13 @@ requires-python = ">=3.10"
 Homepage = "https://github.com/open-spaced-repetition/py-fsrs"
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv", "pytest-xdist", "pdoc", "tqdm", "pytest-cov", "mypy"]
+dev = ["pytest", "ruff", "setuptools", "torch", "numpy", "pandas", "uv", "pytest-xdist", "pdoc", "tqdm", "pytest-cov", "ty"]
 optimizer = ["torch", "numpy", "pandas", "tqdm"]
 
 [tool.pytest.ini_options]
 pythonpath = "."
 filterwarnings = ["error"]
 
-[tool.mypy]
-files = ["fsrs"]
-
-[[tool.mypy.overrides]]
-module = ["fsrs.optimizer"]
-ignore_errors = true
+[tool.ty.src]
+include = ["fsrs"]
+exclude = ["fsrs/optimizer.py"]


### PR DESCRIPTION
This PR replaces `mypy` with [ty](https://github.com/astral-sh/ty) as py-fsrs's static type checker. `ty` is developed by the same people as `ruff` and `uv`. Even though `ty` is still technically in development, I thought it would be interesting to include in this project - especially as the tool becomes more mature. This PR is also similar to #124 but has been completed.

In sum, I did the following:
1. Replaced `mypy` with `ty` in our optional `dev` dependencies in the `pyproject.toml`
2. Replaced `mypy` with `ty` in our `type-check.yml` gh workflow.
3. Updated the README and CONTRIBUTING to reflect moving from mypy to ty