### PR TITLE
Constrain the `optimizer` extra via markers.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ optimizer = [
     "numpy; python_version >= '3.10' and python_version < '3.14'",
     "pandas; python_version >= '3.10' and python_version < '3.14'",
     "tqdm; python_version >= '3.10' and python_version < '3.14'",
+    "optimizer_is_not_available_for_python_3.14; python_version >= '3.14'",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Re: https://discuss.python.org/t/idea-specify-python-version-constraints-on-optional-dependencies-in-a-pyproject-toml/104321/1

It's not as convenient as your suggested syntax in the post, but
anywhere the Python packaging ecosystem accepts a requirement, it
 accepts a marker. I've added markers to the 4 optimized optional
dependencies as an equivalent way that works today to get what I think
you're asking for.

For more on markers see:
  https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers