### PR TITLE
Fix docs gh action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python with uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.13'
 


### PR DESCRIPTION
The recent `docs.yml` gh action run failed ([link](https://github.com/open-spaced-repetition/py-fsrs/actions/runs/18457936966/job/52582770192)) after the release of 6.3.0 due to the action using `actions/setup-python@v5` instead of `astral-sh/setup-uv@v5`. This PR fixes that.

After this gets merged, I'll rerun this action and make sure the latest docs are available.