### PR TITLE
Fix ty error and suppress warnings

### DIFF
--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -658,7 +658,9 @@ class Scheduler:
         )
 
         if not isinstance(next_interval, Real):  # type(next_interval) is torch.Tensor
-            next_interval = next_interval.detach().item()
+            next_interval = (
+                next_interval.detach().item()  # ty: ignore[possibly-missing-attribute]
+            )
 
         next_interval = round(next_interval)  # intervals are full days
 
@@ -679,7 +681,7 @@ class Scheduler:
             if isinstance(short_term_stability_increase, Real):
                 short_term_stability_increase = max(short_term_stability_increase, 1.0)
             else:  # type(short_term_stability_increase) is torch.Tensor
-                short_term_stability_increase = short_term_stability_increase.clamp(
+                short_term_stability_increase = short_term_stability_increase.clamp(  # ty: ignore[possibly-missing-attribute]
                     min=1.0
                 )
 


### PR DESCRIPTION
Will probably close #149

With the recent update of ty, our type-check.yml gh workflow is now failing. This was due to to one error in `get_card_retrievability()`.

Additionally, there were two new warnings associated with the torch-related code in the scheduler module. I've suppressed those since I'm not really sure how to handle that given that torch is conditionally imported.

Lmk if you have any questions 👍