### PR TITLE
Fix same-day Hard stability floor

### DIFF
--- a/fsrs/scheduler.py
+++ b/fsrs/scheduler.py
@@ -697,7 +697,7 @@ class Scheduler:
             math.e ** (self.parameters[17] * (rating - 3 + self.parameters[18]))
         ) * (stability ** -self.parameters[19])
 
-        if rating in (Rating.Good, Rating.Easy):
+        if rating in (Rating.Hard, Rating.Good, Rating.Easy):
             if isinstance(short_term_stability_increase, (int, float)):
                 short_term_stability_increase = max(short_term_stability_increase, 1.0)
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fsrs"
-version = "6.3.1"
+version = "6.3.2"
 description = "Free Spaced Repetition Scheduler"
 readme = "README.md"
 authors = [

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -784,6 +784,18 @@ class TestPyFSRS:
             )
             assert card.stability >= STABILITY_MIN
 
+    def test_same_day_hard_review_does_not_decrease_stability(self):
+        scheduler = Scheduler(learning_steps=())
+        review_datetime = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        card, _ = scheduler.review_card(Card(), Rating.Good, review_datetime)
+        previous_stability = card.stability
+
+        card, _ = scheduler.review_card(
+            card, Rating.Hard, review_datetime + timedelta(minutes=1)
+        )
+
+        assert card.stability == previous_stability
+
     def test_scheduler_parameter_validation(self):
         # initializing a Scheduler object with valid parameters works
         good_parameters = DEFAULT_PARAMETERS


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/srs-benchmark/issues/343

This pull request updates the spaced repetition scheduler to improve the handling of "Hard" reviews and adds a corresponding test to ensure stability is not decreased in this scenario. It also bumps the package version.

**Scheduler logic improvements:**

* Modified the `_short_term_stability` method in `fsrs/scheduler.py` so that "Hard" reviews (in addition to "Good" and "Easy") will not decrease stability below 1.0, preventing unintended drops in card stability.

**Testing enhancements:**

* Added `test_same_day_hard_review_does_not_decrease_stability` in `tests/test_basic.py` to verify that a "Hard" review on the same day as a "Good" review does not reduce the card's stability.

**Project versioning:**

* Updated the package version in `pyproject.toml` from `6.3.1` to `6.3.2` to reflect these changes.